### PR TITLE
Add `TypeOperators` where `~` is used (ghc 9.6.3 warning)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ core/test/golden/*/actual
 result*
 .stack-to-nix.cache
 .nix-shell-cabal.project
+.envrc

--- a/core/lib/Cardano/Address/Derivation.hs
+++ b/core/lib/Cardano/Address/Derivation.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_HADDOCK prune #-}
 

--- a/core/test/Cardano/Address/Style/IcarusSpec.hs
+++ b/core/test/Cardano/Address/Style/IcarusSpec.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/core/test/Test/Arbitrary.hs
+++ b/core/test/Test/Arbitrary.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}


### PR DESCRIPTION
GHC 9.6.3 will consider the absence of `TypeOperators` extension a warning when type equality is used, so `-frelease` will not pass

- [x] Add type operators extension where needed