### PR TITLE
Define Roles and Responsibilities

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,15 @@
-# These owners will be the default owners for everything in the repository.
+# Code owners are automatically assigned to review PRs
 #
-# Unless a later match takes precedence, these owners will be requested for
-# review when someone opens a pull request.
-#
-* @paweljakubas @Anviking @HeinrichApfelmus @jonathanknowles @paolino @Unisay
+# Later rules override earlier rules.
+
+# CICD
+.github/          @hamishmack
+nix/              @hamishmack
+
+# Haskell components
+command-line/     @paweljakubas
+core/             @paweljakubas
+
+# JavaScript interface
+jsapi/            @hamishmack
+jsbits/           @hamishmack

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,13 +3,13 @@
 # Later rules override earlier rules.
 
 # CICD
-.github/          @hamishmack
-nix/              @hamishmack
+.github/          @Crypto2099 
+nix/              @Crypto2099 
 
 # Haskell components
 command-line/     @paweljakubas
 core/             @paweljakubas
 
 # JavaScript interface
-jsapi/            @hamishmack
-jsbits/           @hamishmack
+jsapi/            @Crypto2099
+jsbits/           @Crypto2099

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing to cardano-addresses
+
 If you find a bug or you'd like to propose a feature, please feel free to raise
 an issue on our [issue tracker](https://github.com/IntersectMBO/cardano-addresses/issues).
 
@@ -5,3 +7,21 @@ Pull requests are welcome!
 
 When creating a pull request, please make sure that your code adheres to our
 [coding standards](https://github.com/input-output-hk/adrestia/blob/master/docs/code/Coding-Standards.md).
+
+## Roles and Responsibilities
+
+The `cardano-addresses` repository is co-maintained by @intersectmbo and @cardano-foundation.
+
+The following people hold key responsibilities:
+
+* @disassembler is responsible for releases
+* @hamishmack is responsible for compilation to JavaScript and CI
+* @paweljakubas is responsible for the Haskell components
+
+Regular contributors for the Haskell components are
+
+* @Anviking @HeinrichApfelmus @jonathanknowles @paweljakubas @paolino
+
+all of whom can merge PRs and be asked to review them.
+
+In addition, the CODEOWNERS file identifies specific reviewers who are required for PRs that affect specific components.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The `cardano-addresses` repository is co-maintained by @intersectmbo and @cardan
 The following people hold key responsibilities:
 
 * @disassembler is responsible for releases
-* @hamishmack is responsible for compilation to JavaScript and CI
+* @Crypto2099 is responsible for compilation to JavaScript and CI
 * @paweljakubas is responsible for the Haskell components
 
 Regular contributors for the Haskell components are


### PR DESCRIPTION
This pull request defines [roles and responsibilities][1] for this repository, following the [Project management policy](https://input-output-hk.github.io/cardano-engineering-handbook/policy/project/index.html#project-management) of the [Cardano Engineering Handbook](https://input-output-hk.github.io/cardano-engineering-handbook/).

For the Haskell components, the @cardano-foundation is willing to take responsibility; I have written down corresponding names.

For the CI and JavaScript parts, @intersectmbo will have to be responsible. I have put down some tentative names there, but please feel free to change them.

  [1]: https://input-output-hk.github.io/cardano-engineering-handbook/policy/project/index.html#roles-and-responsibilities