### PR TITLE
Fix windows utf-8 issues

### DIFF
--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -161,6 +161,9 @@ test-suite unit
     , temporary
     , text
     , with-utf8
+  if os(windows)
+    build-depends:
+        Win32
   if flag(release)
     ghc-options: -Werror
   if !(impl(ghcjs) || os(ghcjs))

--- a/command-line/test/Main.hs
+++ b/command-line/test/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 
 import Prelude
@@ -11,7 +12,29 @@ import Test.Hspec.Runner
 
 import qualified AutoDiscover
 
+-- This is effectively from the now defunct foundation/basement from
+--  https://github.com/haskell-foundation/foundation/blob/5e28e3ea1e2fe9a98c157df463bd32d3f92e7f80/basement/Basement/Terminal.hs#L14-L26
+#ifdef mingw32_HOST_OS
+import System.IO (hSetEncoding, utf8, hPutStrLn, stderr, stdin, stdout)
+import System.Win32.Console (setConsoleCP, setConsoleOutputCP, getConsoleCP, getConsoleOutputCP)
+#endif
+
+initialize :: IO ()
+initialize = do
+#ifdef mingw32_HOST_OS
+    query getConsoleOutputCP (\e -> setConsoleOutputCP e >> hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) utf8Code
+    query getConsoleCP (\e -> setConsoleCP e >> hSetEncoding stdin utf8) utf8Code
+  where
+    utf8Code = 65001
+    query get set expected = do
+        v <- get
+        if v == expected then pure () else set expected
+#else
+    pure ()
+#endif
+
 main :: IO ()
 main = do
     ghcjsBuildSupport
+    initialize
     withUtf8 $ hspecWith defaultConfig AutoDiscover.spec

--- a/command-line/test/Main.hs
+++ b/command-line/test/Main.hs
@@ -19,9 +19,9 @@ import System.IO (hSetEncoding, utf8, hPutStrLn, stderr, stdin, stdout)
 import System.Win32.Console (setConsoleCP, setConsoleOutputCP, getConsoleCP, getConsoleOutputCP)
 #endif
 
+#ifdef mingw32_HOST_OS
 initialize :: IO ()
 initialize = do
-#ifdef mingw32_HOST_OS
     query getConsoleOutputCP (\e -> setConsoleOutputCP e >> hSetEncoding stdout utf8 >> hSetEncoding stderr utf8) utf8Code
     query getConsoleCP (\e -> setConsoleCP e >> hSetEncoding stdin utf8) utf8Code
   where
@@ -29,12 +29,12 @@ initialize = do
     query get set expected = do
         v <- get
         if v == expected then pure () else set expected
-#else
-    pure ()
 #endif
 
 main :: IO ()
 main = do
     ghcjsBuildSupport
+#ifdef mingw32_HOST_OS
     initialize
+#endif
     withUtf8 $ hspecWith defaultConfig AutoDiscover.spec

--- a/command-line/test/Main.hs
+++ b/command-line/test/Main.hs
@@ -15,8 +15,10 @@ import qualified AutoDiscover
 -- This is effectively from the now defunct foundation/basement from
 --  https://github.com/haskell-foundation/foundation/blob/5e28e3ea1e2fe9a98c157df463bd32d3f92e7f80/basement/Basement/Terminal.hs#L14-L26
 #ifdef mingw32_HOST_OS
-import System.IO (hSetEncoding, utf8, hPutStrLn, stderr, stdin, stdout)
-import System.Win32.Console (setConsoleCP, setConsoleOutputCP, getConsoleCP, getConsoleOutputCP)
+import System.IO
+    ( hPutStrLn, hSetEncoding, stderr, stdin, stdout, utf8 )
+import System.Win32.Console
+    ( getConsoleCP, getConsoleOutputCP, setConsoleCP, setConsoleOutputCP )
 #endif
 
 #ifdef mingw32_HOST_OS

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -54,6 +54,7 @@ haskell-nix.cabalProject' (
       };
       crossPlatforms = p: with p;
         lib.optional (system == "x86_64-linux" && builtins.elem config.compiler-nix-name ["ghc8107"]) ghcjs ++
+        lib.optional (system == "x86_64-linux") mingwW64 ++
         lib.optional (system == "x86_64-linux") musl64;
     };
     shell = {


### PR DESCRIPTION
This ensure we force the rigth codepages on windows to support utf8 caracters in the haskell source for the tests.