### PR TITLE
Drop GHC 9.2.8 from the GHA matrix

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.6.5"]
+        ghc: ["8.10.7", "9.6.5"]
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, windows-latest]
 


### PR DESCRIPTION
I really think we don't want to run tests for that.