### PR TITLE
Nix based GHAs for easy reproducibility and cross compilation

### DIFF
--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -39,13 +39,13 @@ jobs:
         run: echo "CACHE_VERSION=devxcache0" >> $GITHUB_ENV
 
       - name: Cabal update
-        run: $HOME/bin/cabalcabal update
+        run: cabal update
 
       - name: "Setup cabal-store"
         id: cabal-store
         shell: bash
         run: |
-          cabal_config_file="$($HOME/bin/cabal help user-config | tail -n 1 | xargs)"
+          cabal_config_file="$(cabal help user-config | tail -n 1 | xargs)"
           echo "cabal-store=$(dirname "$cabal_config_file")/store" | tee -a "$GITHUB_OUTPUT"
 
       - name: "Check cabal-store"
@@ -68,7 +68,7 @@ jobs:
       - name: Record dependencies
         id: record-deps
         run: |
-          $HOME/bin/cabal build all --dry-run
+          cabal build all --dry-run
           cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
 
       - name: "OUTPUT Record weeknum"
@@ -94,13 +94,13 @@ jobs:
           restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}${{matrix.target-platform}}
 
       - name: Install dependencies
-        run: $HOME/bin/cabal build all --only-dependencies
+        run: cabal build all --only-dependencies
 
       - name: Build
-        run: $HOME/bin/cabal build all
+        run: cabal build all
 
       - name: Run unit tests
         shell: bash
         run: |
-          $HOME/bin/cabal test cardano-addresses --test-show-details=direct
-          $HOME/bin/cabal test cardano-addresses-cli --test-show-details=direct
+          cabal test cardano-addresses --test-show-details=direct
+          cabal test cardano-addresses-cli --test-show-details=direct

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -17,6 +17,9 @@ jobs:
         platform: [ x86_64-linux, x86_64-darwin ]
         compiler-nix-name: [ ghc810, ghc96 ]
         target-platform: [ "", "-windows" ]
+        exclude:
+          - platform: x86_64-darwin
+            target-platform: "-windows"
 
     runs-on: ${{ matrix.platform == 'x86_64-linux' && 'ubuntu-latest' || 'macos-latest' }}
     steps:
@@ -42,7 +45,8 @@ jobs:
         id: cabal-store
         shell: bash
         run: |
-          cabal_config_file="$(PATH=$HOME/bin:$PATH cabal help user-config | tail -n 1 | xargs)"
+          export PATH=$HOME/bin:$PATH
+          cabal_config_file="$(cabal help user-config | tail -n 1 | xargs)"
           echo "cabal-store=$(dirname "$cabal_config_file")/store" | tee -a "$GITHUB_OUTPUT"
 
       - name: "Check cabal-store"

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -32,8 +32,8 @@ jobs:
       - name: add patched cabal
         run: |
           mkdir ~/bin
-          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/x86_64-linux.cabal-install-static/latest/download/1 | gunzip > ~/bin/cabal
-          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/x86_64-linux.cabal-install-hooks/latest/download/1 | tar xzf - -C ~/bin
+          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/${{ matrix.platform }}.cabal-install-static/latest/download/1 | gunzip > ~/bin/cabal
+          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/${{ matrix.platform }}.cabal-install-hooks/latest/download/1 | tar xzf - -C ~/bin
           chmod +x ~/bin/cabal
           chmod +x ~/bin/*Hook*
       - name: cabal update

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -1,0 +1,52 @@
+name: DevX/Haskell
+on:
+  push:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: devx {0}
+ 
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ x86_64-linux, x86_64-darwin ]
+        compiler-nix-name: [ ghc810, ghc96 ]
+        target-platform: [ "" ] # , "-windows" ]
+
+    runs-on: ${{ matrix.platform == 'x86_64-linux' && 'ubuntu-latest' || 'macos-latest' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install GHC and Cabal
+        uses: input-output-hk/actions/devx@latest
+        with:
+          platform: ${{ matrix.platform }}
+          target-platform: ${{ matrix.target-platform }}
+          compiler-nix-name: ${{ matrix.compiler-nix-name }}
+          # for now we'll set minimal to false, as minimal-iog images don't exist.
+          minimal: false
+          iog: true
+      - name: add patched cabal
+        run: |
+          mkdir ~/bin
+          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/x86_64-linux.cabal-install-static/latest/download/1 | gunzip > ~/bin/cabal
+          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/x86_64-linux.cabal-install-hooks/latest/download/1 | tar xzf - -C ~/bin
+          chmod +x ~/bin/cabal
+          chmod +x ~/bin/*Hook*
+      - name: cabal update
+        run: PATH=$HOME/bin:$PATH cabal update
+      - name: cabal build dependencies
+        env:
+          CABAL_AWS_ACCESS_KEY_ID: ${{ secrets.CABAL_AWS_ACCESS_KEY_ID }}
+          CABAL_AWS_SECRET_ACCESS_KEY: ${{ secrets.CABAL_AWS_SECRET_ACCESS_KEY }}
+        run: PATH=$HOME/bin:$PATH cabal build all -j --enable-tests --only-dependencies
+      - name: cabal build
+        env:
+          CABAL_AWS_ACCESS_KEY_ID: ${{ secrets.CABAL_AWS_ACCESS_KEY_ID }}
+          CABAL_AWS_SECRET_ACCESS_KEY: ${{ secrets.CABAL_AWS_SECRET_ACCESS_KEY }}
+        run: PATH=$HOME/bin:$PATH cabal build all -j --enable-tests
+      - name: cabal test
+        run: PATH=$HOME/bin:$PATH cabal test all -j --enable-tests --test-show-details=direct

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -16,10 +16,14 @@ jobs:
       matrix:
         platform: [ x86_64-linux, x86_64-darwin ]
         compiler-nix-name: [ ghc810, ghc96 ]
-        target-platform: [ "", "-windows" ]
+        target-platform: [ "", "-windows" "-js" ]
         exclude:
           - platform: x86_64-darwin
             target-platform: "-windows"
+          - platform: x86_64-darwin
+            target-platform: "-js"
+          - compiler-nix-name: ghc96
+            target-platform: "-js"
 
     runs-on: ${{ matrix.platform == 'x86_64-linux' && 'ubuntu-latest' || 'macos-latest' }}
     steps:

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -1,6 +1,8 @@
 name: DevX/Haskell
 on:
   push:
+    branches: [ "master" ]
+  pull_request:
   workflow_dispatch:
 
 defaults:
@@ -14,7 +16,7 @@ jobs:
       matrix:
         platform: [ x86_64-linux, x86_64-darwin ]
         compiler-nix-name: [ ghc810, ghc96 ]
-        target-platform: [ "" ] # , "-windows" ]
+        target-platform: [ "", "-windows" ]
 
     runs-on: ${{ matrix.platform == 'x86_64-linux' && 'ubuntu-latest' || 'macos-latest' }}
     steps:
@@ -29,24 +31,73 @@ jobs:
           # for now we'll set minimal to false, as minimal-iog images don't exist.
           minimal: false
           iog: true
-      - name: add patched cabal
-        run: |
-          mkdir ~/bin
-          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/${{ matrix.platform }}.cabal-install-static/latest/download/1 | gunzip > ~/bin/cabal
-          curl -L https://ci.zw3rk.com/job/input-output-hk-haskell-nix-example/pullrequest-2/${{ matrix.platform }}.cabal-install-hooks/latest/download/1 | tar xzf - -C ~/bin
-          chmod +x ~/bin/cabal
-          chmod +x ~/bin/*Hook*
-      - name: cabal update
+
+      - name: Set cache version
+        run: echo "CACHE_VERSION=devxcache0" >> $GITHUB_ENV
+
+      - name: Cabal update
         run: PATH=$HOME/bin:$PATH cabal update
-      - name: cabal build dependencies
-        env:
-          CABAL_AWS_ACCESS_KEY_ID: ${{ secrets.CABAL_AWS_ACCESS_KEY_ID }}
-          CABAL_AWS_SECRET_ACCESS_KEY: ${{ secrets.CABAL_AWS_SECRET_ACCESS_KEY }}
-        run: PATH=$HOME/bin:$PATH cabal build all -j --enable-tests --only-dependencies
-      - name: cabal build
-        env:
-          CABAL_AWS_ACCESS_KEY_ID: ${{ secrets.CABAL_AWS_ACCESS_KEY_ID }}
-          CABAL_AWS_SECRET_ACCESS_KEY: ${{ secrets.CABAL_AWS_SECRET_ACCESS_KEY }}
-        run: PATH=$HOME/bin:$PATH cabal build all -j --enable-tests
-      - name: cabal test
-        run: PATH=$HOME/bin:$PATH cabal test all -j --enable-tests --test-show-details=direct
+
+      - name: "Setup cabal-store"
+        id: cabal-store
+        shell: bash
+        run: |
+          cabal_config_file="$(PATH=$HOME/bin:$PATH cabal help user-config | tail -n 1 | xargs)"
+          echo "cabal-store=$(dirname "$cabal_config_file")/store" | tee -a "$GITHUB_OUTPUT"
+
+      - name: "Check cabal-store"
+        shell: bash
+        run: echo '${{ steps.cabal-store.outputs.cabal-store }}'
+
+      - name: Configure build
+        shell: bash
+        run: |
+          if [ "${{github.event.inputs.tests}}" == "all" ]; then
+            echo "Reconfigure cabal projects to run tests for all dependencies"
+            sed -i 's|tests: False|tests: True|g' cabal.project
+          fi
+
+          cp ".github/workflows/cabal.project.local.ci.$(uname -s)" cabal.project.local
+
+          echo "# cabal.project.local"
+          cat cabal.project.local
+
+      - name: Record dependencies
+        id: record-deps
+        run: |
+          PATH=$HOME/bin:$PATH cabal build all --dry-run
+          cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
+
+      - name: "OUTPUT Record weeknum"
+        shell: bash
+        run: echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
+
+      - name: Cache Cabal store
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cabal-store.outputs.cabal-store }}
+          key: cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}${{matrix.target-platform}}-${{ hashFiles('dependencies.txt') }}
+          restore-keys: |
+            cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}${{matrix.target-platform}}-${{ hashFiles('dependencies.txt') }}
+            cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}${{matrix.target-platform}}
+
+      - uses: actions/cache@v2
+        name: "Cache `dist-newstyle`"
+        with:
+          path: |
+            dist-newstyle
+            !dist-newstyle/**/.git
+          key: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}${{matrix.target-platform}}-${{ steps.record-deps.outputs.weeknum }}
+          restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}${{matrix.target-platform}}
+
+      - name: Install dependencies
+        run: PATH=$HOME/bin:$PATH cabal build all --only-dependencies
+
+      - name: Build
+        run: PATH=$HOME/bin:$PATH cabal build all
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          PATH=$HOME/bin:$PATH cabal test cardano-addresses --test-show-details=direct
+          PATH=$HOME/bin:$PATH cabal test cardano-addresses-cli --test-show-details=direct

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -39,14 +39,13 @@ jobs:
         run: echo "CACHE_VERSION=devxcache0" >> $GITHUB_ENV
 
       - name: Cabal update
-        run: PATH=$HOME/bin:$PATH cabal update
+        run: $HOME/bin/cabalcabal update
 
       - name: "Setup cabal-store"
         id: cabal-store
         shell: bash
         run: |
-          export PATH=$HOME/bin:$PATH
-          cabal_config_file="$(cabal help user-config | tail -n 1 | xargs)"
+          cabal_config_file="$($HOME/bin/cabal help user-config | tail -n 1 | xargs)"
           echo "cabal-store=$(dirname "$cabal_config_file")/store" | tee -a "$GITHUB_OUTPUT"
 
       - name: "Check cabal-store"
@@ -69,7 +68,7 @@ jobs:
       - name: Record dependencies
         id: record-deps
         run: |
-          PATH=$HOME/bin:$PATH cabal build all --dry-run
+          $HOME/bin/cabal build all --dry-run
           cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
 
       - name: "OUTPUT Record weeknum"
@@ -95,13 +94,13 @@ jobs:
           restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}${{matrix.target-platform}}
 
       - name: Install dependencies
-        run: PATH=$HOME/bin:$PATH cabal build all --only-dependencies
+        run: $HOME/bin/cabal build all --only-dependencies
 
       - name: Build
-        run: PATH=$HOME/bin:$PATH cabal build all
+        run: $HOME/bin/cabal build all
 
       - name: Run unit tests
         shell: bash
         run: |
-          PATH=$HOME/bin:$PATH cabal test cardano-addresses --test-show-details=direct
-          PATH=$HOME/bin:$PATH cabal test cardano-addresses-cli --test-show-details=direct
+          $HOME/bin/cabal test cardano-addresses --test-show-details=direct
+          $HOME/bin/cabal test cardano-addresses-cli --test-show-details=direct

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         platform: [ x86_64-linux, x86_64-darwin ]
         compiler-nix-name: [ ghc810, ghc96 ]
-        target-platform: [ "", "-windows" "-js" ]
+        target-platform: [ "", "-windows", "-js" ]
         exclude:
           - platform: x86_64-darwin
             target-platform: "-windows"

--- a/.github/workflows/devx.yml
+++ b/.github/workflows/devx.yml
@@ -43,17 +43,14 @@ jobs:
 
       - name: "Setup cabal-store"
         id: cabal-store
-        shell: bash
         run: |
           cabal_config_file="$(cabal help user-config | tail -n 1 | xargs)"
           echo "cabal-store=$(dirname "$cabal_config_file")/store" | tee -a "$GITHUB_OUTPUT"
 
       - name: "Check cabal-store"
-        shell: bash
         run: echo '${{ steps.cabal-store.outputs.cabal-store }}'
 
       - name: Configure build
-        shell: bash
         run: |
           if [ "${{github.event.inputs.tests}}" == "all" ]; then
             echo "Reconfigure cabal projects to run tests for all dependencies"
@@ -72,7 +69,6 @@ jobs:
           cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
 
       - name: "OUTPUT Record weeknum"
-        shell: bash
         run: echo "weeknum=$(/usr/bin/date -u "+%W")" >> $GITHUB_OUTPUT
 
       - name: Cache Cabal store
@@ -100,7 +96,6 @@ jobs:
         run: cabal build all
 
       - name: Run unit tests
-        shell: bash
         run: |
           cabal test cardano-addresses --test-show-details=direct
           cabal test cardano-addresses-cli --test-show-details=direct


### PR DESCRIPTION
This reuses our haskell.nix infrastructure through the input-output-hk/devx repository to build GHAs that effectively run
```
nix develop github:input-output-hk/devx#ghc<ver>-minimal-iog
```
(as well as JavaScript and Windows cross).

This is distinctly different from running the GHA using input-outpu-hk/actions/base + haskell, in that they use linux and macOS builder only (windows is cross compiled on linux). Re-using the same infrastructure we use to build full nix builds as well, however, building the application in a _shell_. Thus you effectively use nix to _provision_ the environment, while using usual tools (cabal, ghc, ...) to actually _build_ the software.

This also means, you can trivially debug the situation in CI, by simply sparing the same local shell on you linux (and macOS) machine. It also means we should soon be able to debug windows cross (and javascript cross) topics fairly easily.