### PR TITLE
CIP 0105 CLI support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 ### Added
 
  - `hashKey` for Shelley style
- - Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://cips.cardano.org/cips/cip0105/). Also supported in CLI.
+ - Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105). Also supported in CLI.
 
 ## [3.13.0] - N/A
 
@@ -34,7 +34,7 @@
 
 ### Added
 
-- Support for policy key derivation and hashing according to [CIP-1855](https://cips.cardano.org/cips/cip1855/).
+- Support for policy key derivation and hashing according to [CIP-1855](https://github.com/cardano-foundation/CIPs/tree/master/CIP-1855).
 
 ## [3.8.0] - 2022-02-11
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+## [3.14.0] - N/A
+
+### Added
+
+ - `hashKey` for Shelley style
+ - Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://cips.cardano.org/cips/cip0105/). Also supported in CLI.
+
 ## [3.13.0] - N/A
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ cc_hot1xk94yxqufrm5sjfv535hlnky8cf9fzg5kvp3r4qz9d5ezua5p8v
 </details>
 
 <details>
-  <summary>How to generate script and script hash from drep (<strong>drep_script</strong>)</summary>
+  <summary>How to generate script validation, preimage and script hash from script composed of drep (<strong>drep_script</strong>)</summary>
 
 ```console
 $ cat drep

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Please enter base64-encoded passphrase:
 root_xsk1jqx0xpke7de69ceyk20tdl9rq7nsava7cfnyeu42yqum8usnpppwmsxn2qsfj0nn2ur2kuq0kmrll67ryvkdhd6pgpsls6s6qx7hlyv6uqt0907t73eflkpw3xz45lcg5fsh6dunfk56j08jslh6x6rttspfny8c
 
 $ echo "3BQ087RygQ1WQJ+F" > base64.prv
-[pawel@arch testingCardanoAddresses]$ cardano-address key from-recovery-phrase Shelley --passphrase from-base64 --from-file "./base64.prv" < phrase.prv
+$ cardano-address key from-recovery-phrase Shelley --passphrase from-base64 --from-file "./base64.prv" < phrase.prv
 root_xsk1jqx0xpke7de69ceyk20tdl9rq7nsava7cfnyeu42yqum8usnpppwmsxn2qsfj0nn2ur2kuq0kmrll67ryvkdhd6pgpsls6s6qx7hlyv6uqt0907t73eflkpw3xz45lcg5fsh6dunfk56j08jslh6x6rttspfny8c
 
 $ cardano-address key from-recovery-phrase Shelley --passphrase from-octets
@@ -577,6 +577,83 @@ $ cardano-address address stake --network-tag testnet "all [$(cat addr_shared.1.
 stake_test17z03zgfexpfvka0l6z94shk2dknjqu8pv85lk2hkwcakdhgx52yaj
 ```
 </details>
+
+<details>
+  <summary>How to generate drep keys (<strong>drep</strong>)</summary>
+
+```console
+$ cat ../tests/root.xsk
+root_xsk1hqzfzrgskgnpwskxxrv5khs7ess82ecy8za9l5ef7e0afd2849p3zryje8chk39nxtva0sww5me3pzkej4rvd5cae3q3v8eu7556n6pdrp4fdu8nsglynpmcppxxvfdyzdz5gfq3fefjepxhvqspmuyvmvqg8983
+
+$ cardano-address key child 1852H/1815H/0H/3/0 < root.xsk > drep.xsk
+drep_xsk1vpdsm49smzmdwhd4kjmm2mdyljjysm746rafjr7r8kgfanj849psw8pfm305g59wng0akw3qzppmfh6k5z7gx66h2vppu022m4eqaj26rh6d7en9tf9fu52hmysjzuacaxfmfya65h8jmddrclwf3kxl8snfs3eg
+
+$ cardano-address key public --with-chain-code < drep.xsk > drep.xvk
+drep_xvk1mg7xae48d7z4nntd35tey0jmclxaavwmk3kw2lkkt07p3s3x3yy45805manx2kj2neg40kfpy9em36vnkjfm4fw09k66837unrvd70qq8ewzf
+
+$ cardano-address key hash < drep.xvk > drep
+drep1sp5xhvmj0asztqfsjyta3cwvq7jppc2rwmfcsggp62va538nup0
+```
+</details>
+
+
+<details>
+  <summary>How to generate cold committee keys (<strong>cc_cold</strong>)</summary>
+
+```console
+$ cat root.xsk
+root_xsk1hqzfzrgskgnpwskxxrv5khs7ess82ecy8za9l5ef7e0afd2849p3zryje8chk39nxtva0sww5me3pzkej4rvd5cae3q3v8eu7556n6pdrp4fdu8nsglynpmcppxxvfdyzdz5gfq3fefjepxhvqspmuyvmvqg8983
+
+$ cardano-address key child 1852H/1815H/0H/4/0 < root.xsk > cold.xsk
+cc_cold_xsk1fp4megtpn4vu4cug2lmsyhg4xvnnar55q6k8wp5e6f2h8jz849ph8v8jhm0qffw8v6ut7x8wqvr07m9ccaspezrkexcafu284w6gpqexspqujj8glw0d70rwuemk0924zjhscgcfnevy29zr0fc57tvjmg7jvvqh
+
+$ cardano-address key public --with-chain-code < cold.xsk > cold.xvk
+cc_cold_xvk1dg8d5du0v4ukqkfgset50xncudhwlfzz2p6epv096x0ndl8jsgzzdqzpe9yw37u7mu7xaenhv7242990ps3sn8jcg52yx7n3fuke9kst5t2py
+
+$ cardano-address key hash < cold.xvk > cold
+cc_cold1d7yw362prvnae5fc8063xdeapws9ptzdgjkqd4dk3qddccyzfjm
+```
+</details>
+
+<details>
+  <summary>How to generate hot committee keys (<strong>cc_hot</strong>)</summary>
+
+```console
+$ cat root.xsk
+root_xsk1hqzfzrgskgnpwskxxrv5khs7ess82ecy8za9l5ef7e0afd2849p3zryje8chk39nxtva0sww5me3pzkej4rvd5cae3q3v8eu7556n6pdrp4fdu8nsglynpmcppxxvfdyzdz5gfq3fefjepxhvqspmuyvmvqg8983
+
+$ cardano-address key child 1852H/1815H/0H/5/0 < root.xsk > hot.xsk
+cc_hot_xsk14z9ktfggpsm8sqd5ecepv9f4estxkukfualezuxrfry0mjj849puxsq7ch3tw67d7rfr4smvaa2u3tkfu675mxw85zlpafp6llfex7re88wh22s8f83ehn6uejgfrm74x8y98xlwdmgy64ufctwernp64umnr5uk
+
+$ cardano-address key public --with-chain-code < hot.xsk > hot.xvk
+cc_hot_xvk1a5q4r34xzm0r6y728d4gmrl7jvrfuh7r022k7wh5mzwmyg7d7l3hjwwaw54qwj0rn084enysj8ha2vwg2wd7umksf4tcnskaj8xr4tcempwly
+
+$ cardano-address key hash < hot.xvk > hot
+cc_hot1xk94yxqufrm5sjfv535hlnky8cf9fzg5kvp3r4qz9d5ezua5p8v
+```
+</details>
+
+<details>
+  <summary>How to generate script and script hash from drep (<strong>drep_script</strong>)</summary>
+
+```console
+$ cat drep
+drep1sp5xhvmj0asztqfsjyta3cwvq7jppc2rwmfcsggp62va538nup0
+
+$ cardano-address script validate "all [$(cat drep),active_from 5001]"
+Validated.
+
+$ cardano-address script validate "all [$(cat drep),$(cat hot)]"
+Not validated: All keys of a script must have the same role: payment, delegation, policy, representative, committee cold or committee hot.
+
+$ cardano-address script preimage "all [$(cat drep),active_from 5001]"
+008201828200581c80686bb3727f602581309117d8e1cc07a410e14376d3882101d299da8204191389
+
+$ cardano-address script hash "all [$(cat drep),active_from 5001]"
+drep_script1608hfeauc3hvfpvdcqwfdhyd2cfm6j42rp62ckqrskazy57w2zt
+```
+</details>
+
 
 <details>
   <summary>Correspondence between keys in cardano-addresses and cardano-cli (<strong>key.xsk key.xvk key.vk key.hash</strong>)</summary>

--- a/cabal.project
+++ b/cabal.project
@@ -14,11 +14,11 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 
 repository ghcjs-overlay
-  url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/8ef1977ba226b9dea0a5f43824c2e3507280d306
+  url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/b91c23d847a5ecedc3eca2e054afd1e8c4155256
   secure: True
   root-keys:
   key-threshold: 0
-  --sha256: sha256-jcOUSw6rtBdLXx5/yx1EMKaYfvVWJgpTVe567jA81Ls=
+  --sha256: sha256-d+GumypPpDWxt4PtareJBHkIiWb09l/GskWnWcgDOQE=
 
 -- Avoid conflict in `hjsonschema`
 -- src/Import.hs:2:16: error: [GHC-69158]

--- a/cabal.project
+++ b/cabal.project
@@ -14,11 +14,11 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 
 repository ghcjs-overlay
-  url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/e2b9e88c2aa57b0e33dfb57515be470b520dd621
+  url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/8ef1977ba226b9dea0a5f43824c2e3507280d306
   secure: True
   root-keys:
   key-threshold: 0
-  --sha256: sha256-vzK5NqphLXM+WEn73LfwQDN6Frbhqvy/7TeSRajQL0c=
+  --sha256: sha256-jcOUSw6rtBdLXx5/yx1EMKaYfvVWJgpTVe567jA81Ls=
 
 -- Avoid conflict in `hjsonschema`
 -- src/Import.hs:2:16: error: [GHC-69158]

--- a/command-line/lib/Command/Key/Child.hs
+++ b/command-line/lib/Command/Key/Child.hs
@@ -105,6 +105,8 @@ run Child{path} = do
     --
     --     m / purpose' / coin_type' / account' / role / index
     --
+    -- purpose' = 1852H for shelley wallet addresses.
+    --
     -- We do not allow derivations to anywhere in the path to avoid people
     -- shooting themselves in the foot.
     -- Hence We only allow the following transformations:
@@ -117,9 +119,6 @@ run Child{path} = do
     --
     -- root_xsk => acct_xsk: (hard derivation from root to address)
     --     m => m / purpose' / coin_type' / account' / role / index
-    --
-    -- purpose' = 1852H for shelley wallet addresses.
-    -- purpose' = 1854H for shelley wallet addresses that expose shared account.
     --
     -- acct_xsk => addr_xsk: (hard derivation from account to address)
     --     m / purpose' / coin_type' / account' => m / purpose' / coin_type' / account' / role / index
@@ -157,6 +156,15 @@ run Child{path} = do
         | hrp == CIP5.root_xsk = pure CIP5.stake_xsk
         | hrp == CIP5.root_shared_xsk = pure CIP5.stake_shared_xsk
 
+    childHrpFor [_,_,_,3,0] hrp
+        | hrp == CIP5.root_xsk = pure CIP5.drep_xsk
+
+    childHrpFor [_,_,_,4,0] hrp
+        | hrp == CIP5.root_xsk = pure CIP5.cc_cold_xsk
+
+    childHrpFor [_,_,_,5,0] hrp
+        | hrp == CIP5.root_xsk = pure CIP5.cc_hot_xsk
+
     childHrpFor [p,_,_,_,_] hrp
         | hrp == CIP5.root_xsk =
               -- 2147485502 stands for 1854H
@@ -183,6 +191,18 @@ run Child{path} = do
         | hrp == CIP5.acct_xvk = pure CIP5.stake_xvk
         | hrp == CIP5.acct_shared_xsk = pure CIP5.stake_shared_xsk
         | hrp == CIP5.acct_shared_xvk = pure CIP5.stake_shared_xvk
+
+    childHrpFor [3,0] hrp
+        | hrp == CIP5.acct_xsk = pure CIP5.drep_xsk
+        | hrp == CIP5.acct_xvk = pure CIP5.drep_xvk
+
+    childHrpFor [4,0] hrp
+        | hrp == CIP5.acct_xsk = pure CIP5.cc_cold_xsk
+        | hrp == CIP5.acct_xvk = pure CIP5.cc_cold_xvk
+
+    childHrpFor [5,0] hrp
+        | hrp == CIP5.acct_xsk = pure CIP5.cc_hot_xsk
+        | hrp == CIP5.acct_xvk = pure CIP5.cc_hot_xvk
 
     childHrpFor [_,_] hrp
         | hrp == CIP5.root_xsk = pure CIP5.addr_xsk

--- a/command-line/lib/Command/Key/Hash.hs
+++ b/command-line/lib/Command/Key/Hash.hs
@@ -75,12 +75,29 @@ run Hash{outputFormat} = do
         , ( CIP5.stake_shared_xvk, CIP5.stake_shared_vkh )
         , ( CIP5.policy_vk       , CIP5.policy_vkh  )
         , ( CIP5.policy_xvk      , CIP5.policy_vkh  )
+        , ( CIP5.drep_vk         , CIP5.drep  )
+        , ( CIP5.drep_xvk        , CIP5.drep  )
+        , ( CIP5.cc_cold_vk      , CIP5.cc_cold  )
+        , ( CIP5.cc_cold_xvk     , CIP5.cc_cold  )
+        , ( CIP5.cc_hot_vk       , CIP5.cc_hot  )
+        , ( CIP5.cc_hot_xvk      , CIP5.cc_hot  )
         ]
     allowedPrefixes = map fst prefixes
     prefixFor = fromJust . flip lookup prefixes
 
+    extendedPrefixes =
+        [ CIP5.addr_xvk
+        , CIP5.stake_xvk
+        , CIP5.addr_shared_xvk
+        , CIP5.stake_shared_xvk
+        , CIP5.policy_xvk
+        , CIP5.drep_xvk
+        , CIP5.cc_cold_xvk
+        , CIP5.cc_hot_xvk
+        ]
+
     guardBytes hrp bytes
-        | hrp `elem` [CIP5.addr_xvk, CIP5.stake_xvk, CIP5.addr_shared_xvk, CIP5.stake_shared_xvk, CIP5.policy_xvk] = do
+        | hrp `elem` extendedPrefixes = do
             when (BS.length bytes /= 64) $
                 fail "data should be a 32-byte public key with a 32-byte chain-code appended"
 

--- a/command-line/lib/Command/Key/Inspect.hs
+++ b/command-line/lib/Command/Key/Inspect.hs
@@ -77,6 +77,12 @@ run Inspect = do
         , CIP5.addr_shared_xsk
         , CIP5.stake_shared_xvk
         , CIP5.stake_shared_xsk
+        , CIP5.drep_xvk
+        , CIP5.drep_xsk
+        , CIP5.cc_cold_xvk
+        , CIP5.cc_cold_xsk
+        , CIP5.cc_hot_xvk
+        , CIP5.cc_hot_xsk
         ]
 
     base16 :: ByteString -> Text

--- a/command-line/lib/Command/Key/Public.hs
+++ b/command-line/lib/Command/Key/Public.hs
@@ -70,6 +70,9 @@ run Public{chainCode} = do
         , (CIP5.addr_shared_xsk, (CIP5.addr_shared_xvk, CIP5.addr_shared_vk) )
         , (CIP5.stake_shared_xsk, (CIP5.stake_shared_xvk, CIP5.stake_shared_vk) )
         , (CIP5.policy_xsk, (CIP5.policy_xvk, CIP5.policy_vk) )
+        , (CIP5.drep_xsk, (CIP5.drep_xvk, CIP5.drep_vk) )
+        , (CIP5.cc_cold_xsk, (CIP5.cc_cold_xvk, CIP5.cc_cold_vk) )
+        , (CIP5.cc_hot_xsk, (CIP5.cc_hot_xvk, CIP5.cc_hot_vk) )
         ]
     allowedPrefixes = map fst prefixes
     getCC WithChainCode = fst

--- a/command-line/lib/Command/Script/Hash.hs
+++ b/command-line/lib/Command/Script/Hash.hs
@@ -16,11 +16,13 @@ import Prelude hiding
     ( mod )
 
 import Cardano.Address.Script
-    ( KeyHash (..)
+    ( ErrValidateScript (..)
+    , KeyHash (..)
     , KeyRole (..)
     , Script (..)
     , ScriptHash (..)
     , foldScript
+    , prettyErrValidateScript
     , toScriptHash
     )
 import Codec.Binary.Encoding
@@ -73,9 +75,8 @@ run Cmd{script} = do
     case checkRoles of
         Just role ->
             hPutBytes stdout bytes (EBech32 $ pickCIP5 role)
-        Nothing -> do
-            let err = "Script needs to be constructed using the keys of the same role."
-            hPutString stderr err
+        Nothing ->
+            hPutString stderr (prettyErrValidateScript NotUniformKeyType)
   where
     allKeyHashes = foldScript (:) [] script
     getRole (KeyHash r _) = r

--- a/command-line/lib/Command/Script/Hash.hs
+++ b/command-line/lib/Command/Script/Hash.hs
@@ -87,7 +87,7 @@ run Cmd{script} = do
         else
             Nothing
     pickCIP5 = \case
-        Representative -> CIP5.drep
-        CommitteeCold -> CIP5.cc_cold
-        CommitteeHot -> CIP5.cc_hot
+        Representative -> CIP5.drep_script
+        CommitteeCold -> CIP5.cc_cold_script
+        CommitteeHot -> CIP5.cc_hot_script
         _ -> CIP5.script

--- a/command-line/test/Command/Key/ChildSpec.hs
+++ b/command-line/test/Command/Key/ChildSpec.hs
@@ -23,11 +23,27 @@ spec = describeCmd [ "key", "child" ] $ do
     specChildValidPath "addr_shared_xsk" ["1854H/1815H/0H", "0/0"]
     specChildValidPath "addr_xsk" ["14H/42H"]
     specChildValidPath "policy_xsk" ["1855H/1815H/0H"]
+    specChildValidPath "drep_xsk" ["1852H/1815H/0H/3/0"]
+    specChildValidPath "drep_xsk" ["1852H/1815H/0H", "3/0"]
+    specChildValidPath "drep_xsk" ["1852H/1815H/100H/3/0"]
+    specChildValidPath "cc_cold_xsk" ["1852H/1815H/0H/4/0"]
+    specChildValidPath "cc_cold_xsk" ["1852H/1815H/0H", "4/0"]
+    specChildValidPath "cc_cold_xsk" ["1852H/1815H/100H", "4/0"]
+    specChildValidPath "cc_hot_xsk" ["1852H/1815H/0H/5/0"]
+    specChildValidPath "cc_hot_xsk" ["1852H/1815H/101H/5/0"]
+    specChildValidPath "cc_hot_xsk" ["1852H/1815H/0H", "5/0"]
 
     specChildInvalidPath "from a parent root key" ["0H"]
     specChildInvalidPath "from a parent account key" ["1852H/1815H/0H", "0H"]
 
     specPublicDerivationUsesSoft
+
+    specGovernanceWrongPaths "1852H/1815H/0H/3/1"
+    specGovernanceWrongPaths "1857H/1815H/0H/3/1"
+    specGovernanceWrongPaths "1852H/1815H/0H/4/10"
+    specGovernanceWrongPaths "1858H/1815H/0H/4/10"
+    specGovernanceWrongPaths "1852H/1815H/1H/5/101"
+    specGovernanceWrongPaths "1859H/1815H/1H/5/101"
 
 specChildValidPath :: String -> [String] -> SpecWith ()
 specChildValidPath hrp paths = it ("Can derive given path(s) from root: " <> show paths) $ do
@@ -55,3 +71,10 @@ specPublicDerivationUsesSoft = it "Public derivation requires soft indexes" $ do
     err `shouldContain`
         "Couldn't derive child key. If you're trying to derive children on a \
         \PUBLIC key, you must use soft indexes only."
+
+specGovernanceWrongPaths :: String -> SpecWith ()
+specGovernanceWrongPaths segments = it "Derivation requires addr_ix=0 and 1852H" $ do
+    out <- cli [ "recovery-phrase", "generate" ] ""
+        >>= cli [ "key", "from-recovery-phrase", "shelley" ]
+        >>= cli [ "key", "child", segments ]
+    out `shouldContain` "addr_xsk1"

--- a/command-line/test/Command/Key/HashSpec.hs
+++ b/command-line/test/Command/Key/HashSpec.hs
@@ -29,6 +29,14 @@ spec = describeCmd [ "key", "hash" ] $ do
     specKeyPublic "shelley" "policy_vkh"   "1855H/1815H/0H" "--with-chain-code"
     specKeyPublic "shelley" "policy_vkh"   "1855H/1815H/0H" "--without-chain-code"
 
+    specKeyPublic "shelley" "drep"   "1852H/1815H/0H/3/0" "--with-chain-code"
+    specKeyPublic "shelley" "drep"   "1852H/1815H/0H/3/0" "--without-chain-code"
+    specKeyPublic "shelley" "cc_cold"   "1852H/1815H/0H/4/0" "--with-chain-code"
+    specKeyPublic "shelley" "cc_cold"   "1852H/1815H/0H/4/0" "--without-chain-code"
+    specKeyPublic "shelley" "cc_hot"   "1852H/1815H/0H/5/0" "--with-chain-code"
+    specKeyPublic "shelley" "cc_hot"   "1852H/1815H/0H/5/0" "--without-chain-code"
+
+
 specKeyNotPublic :: SpecWith ()
 specKeyNotPublic = it "fail if key isn't public" $ do
     (out, err) <- cli [ "recovery-phrase", "generate" ] ""

--- a/command-line/test/Command/Key/InspectSpec.hs
+++ b/command-line/test/Command/Key/InspectSpec.hs
@@ -45,6 +45,9 @@ spec = describeCmd [ "key", "inspect" ] $ do
     specInspectPrivate CIP5.addr_shared_xsk
     specInspectPrivate CIP5.stake_shared_xsk
     specInspectPrivate CIP5.policy_xsk
+    specInspectPrivate CIP5.drep_xsk
+    specInspectPrivate CIP5.cc_cold_xsk
+    specInspectPrivate CIP5.cc_hot_xsk
 
     specInspectPublic CIP5.root_xvk
     specInspectPublic CIP5.acct_xvk
@@ -55,6 +58,9 @@ spec = describeCmd [ "key", "inspect" ] $ do
     specInspectPublic CIP5.acct_shared_xvk
     specInspectPublic CIP5.addr_shared_xvk
     specInspectPublic CIP5.stake_shared_xvk
+    specInspectPublic CIP5.drep_xvk
+    specInspectPublic CIP5.cc_cold_xvk
+    specInspectPublic CIP5.cc_hot_xvk
 
 specInspectPrivate :: HumanReadablePart -> SpecWith ()
 specInspectPrivate hrp = it "can inspect private key" $ do

--- a/command-line/test/Command/Script/HashSpec.hs
+++ b/command-line/test/Command/Script/HashSpec.hs
@@ -56,7 +56,7 @@ spec = do
         specScriptHashProper "script10tx7wh633277e0dgw3mkwvmdawrjvdmcz88ypqjzsgxcjr9nwlj"
             [iii|at_least 1 [ #{verKeyH1}, at_least 2 [ #{verKeyH2} ] ]|]
 
-        specScriptHashProper "script163qjya2n5rc6je07ultq5rmjfvmgm5dam0pqsuc0en4u7967saj"
+        specScriptInvalid NotUniformKeyType
             [iii|all []|]
 
         specScriptHashProper "script14uj40hnew0uxrwlfz45z5umqwrs54kd0c04ujzyatyxzsk59wr8"

--- a/command-line/test/Command/Script/HashSpec.hs
+++ b/command-line/test/Command/Script/HashSpec.hs
@@ -44,6 +44,87 @@ spec = do
         specScriptHashProper "script1w8469gq5ed7xtyf2tqdng5yn7ykgckkfcl38xre8hk3ejk2lcwt"
             [iii|#{verKeyH4}|]
 
+        specScriptHashProper "drep_script13hu7a632tuntrlyjkazzczrzzt7dx6e8v3rc25jd9zcgv68nx9r"
+            [iii|all [ #{verKeyH5} ]|]
+
+        specScriptHashProper "drep_script13hu7a632tuntrlyjkazzczrzzt7dx6e8v3rc25jd9zcgv68nx9r"
+            [iii|all [ #{verKey5} ]|]
+
+        specScriptHashProper "drep_script13hu7a632tuntrlyjkazzczrzzt7dx6e8v3rc25jd9zcgv68nx9r"
+            [iii|all [ #{xVerKey5} ]|]
+
+        specScriptHashProper "drep_script16pjhzfkm7rqntfezfkgu5p50t0mkntmdruwlp089zu8v29l95rg"
+            [iii|all [ #{verKeyH5}, active_from 5001]|]
+
+        specScriptHashProper "drep_script16pjhzfkm7rqntfezfkgu5p50t0mkntmdruwlp089zu8v29l95rg"
+            [iii|all [ #{verKeyH5}, active_from 5001 ]|]
+
+        specScriptHashProper "drep_script16pjhzfkm7rqntfezfkgu5p50t0mkntmdruwlp089zu8v29l95rg"
+            [iii|all [ #{verKeyH5}, active_from 5001 ]|]
+
+        specScriptHashProper "drep_script14edv7pg3y4wkglyykvvy5t2j906ld3dhdwvf7jda8qaa63d5kf4"
+            [iii|any [ #{verKeyH5}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "drep_script14edv7pg3y4wkglyykvvy5t2j906ld3dhdwvf7jda8qaa63d5kf4"
+            [iii|any [ #{verKey5}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "drep_script14edv7pg3y4wkglyykvvy5t2j906ld3dhdwvf7jda8qaa63d5kf4"
+            [iii|any [ #{xVerKey5}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "cc_cold_script16e9ypar36jqppdpff86u578w5lvpuf55htkk5cryvj54wd8s4jn"
+            [iii|all [ #{verKeyH6} ]|]
+
+        specScriptHashProper "cc_cold_script16e9ypar36jqppdpff86u578w5lvpuf55htkk5cryvj54wd8s4jn"
+            [iii|all [ #{verKey6} ]|]
+
+        specScriptHashProper "cc_cold_script16e9ypar36jqppdpff86u578w5lvpuf55htkk5cryvj54wd8s4jn"
+            [iii|all [ #{xVerKey6} ]|]
+
+        specScriptHashProper "cc_cold_script14ehj5f64f40xju0086fnunctulkh46mq7munm7upe4hpcwpcatv"
+            [iii|all [ #{verKeyH6}, active_from 5001]|]
+
+        specScriptHashProper "cc_cold_script14ehj5f64f40xju0086fnunctulkh46mq7munm7upe4hpcwpcatv"
+            [iii|all [ #{verKeyH6}, active_from 5001 ]|]
+
+        specScriptHashProper "cc_cold_script14ehj5f64f40xju0086fnunctulkh46mq7munm7upe4hpcwpcatv"
+            [iii|all [ #{verKeyH6}, active_from 5001 ]|]
+
+        specScriptHashProper "cc_cold_script1zxwzpnk0ah7m5ptjjtmkhvgs4736k3e0ns66shd0fy33vdauq3j"
+            [iii|any [ #{verKeyH6}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "cc_cold_script1zxwzpnk0ah7m5ptjjtmkhvgs4736k3e0ns66shd0fy33vdauq3j"
+            [iii|any [ #{verKey6}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "cc_cold_script1zxwzpnk0ah7m5ptjjtmkhvgs4736k3e0ns66shd0fy33vdauq3j"
+            [iii|any [ #{xVerKey6}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "cc_hot_script10fpewpnxmmc7x08nc5yepdyafa8arcaugf3pa37l3qmn2xu0u3c"
+            [iii|all [ #{verKeyH7} ]|]
+
+        specScriptHashProper "cc_hot_script10fpewpnxmmc7x08nc5yepdyafa8arcaugf3pa37l3qmn2xu0u3c"
+            [iii|all [ #{verKey7} ]|]
+
+        specScriptHashProper "cc_hot_script10fpewpnxmmc7x08nc5yepdyafa8arcaugf3pa37l3qmn2xu0u3c"
+            [iii|all [ #{xVerKey7} ]|]
+
+        specScriptHashProper "cc_hot_script16fayy2wf9myfvxmtl5e2suuqmnhy5zx80vxkezen7xqwskncf40"
+            [iii|all [ #{verKeyH7}, active_from 5001]|]
+
+        specScriptHashProper "cc_hot_script16fayy2wf9myfvxmtl5e2suuqmnhy5zx80vxkezen7xqwskncf40"
+            [iii|all [ #{verKeyH7}, active_from 5001 ]|]
+
+        specScriptHashProper "cc_hot_script16fayy2wf9myfvxmtl5e2suuqmnhy5zx80vxkezen7xqwskncf40"
+            [iii|all [ #{verKeyH7}, active_from 5001 ]|]
+
+        specScriptHashProper "cc_hot_script1vts8nrrsxmlntp3v7sh5u7k6qmmlkkmyv5uspq4xjxlpg6u229p"
+            [iii|any [ #{verKeyH7}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "cc_hot_script1vts8nrrsxmlntp3v7sh5u7k6qmmlkkmyv5uspq4xjxlpg6u229p"
+            [iii|any [ #{verKey7}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptHashProper "cc_hot_script1vts8nrrsxmlntp3v7sh5u7k6qmmlkkmyv5uspq4xjxlpg6u229p"
+            [iii|any [ #{xVerKey7}, all [ active_from 5001, active_until 6001]]|]
+
         specScriptInvalid Malformed
             [iii|wrong [ #{verKeyH1} ]|]
 
@@ -99,3 +180,30 @@ verKeyH3 = "addr_shared_vkh175wsm9ckhm3snwcsn72543yguxeuqm7v9r6kl6gx57h8gdydcd9"
 
 verKeyH4 :: String
 verKeyH4 = "addr_shared_vkh1fee6yrlnczhfp77ftunc6snjrv0hv0s92qj2pe47dt4hz8ajp6a"
+
+verKeyH5 :: String
+verKeyH5 = "drep15k6929drl7xt0spvudgcxndryn4kmlzpk4meed0xhqe25nle07s"
+
+verKey5 :: String
+verKey5 = "drep_vk17axh4sc9zwkpsft3tlgpjemfwc0u5mnld80r85zw7zdqcst6w54sdv4a4e"
+
+xVerKey5 :: String
+xVerKey5 = "drep_xvk17axh4sc9zwkpsft3tlgpjemfwc0u5mnld80r85zw7zdqcst6w543mpq3q2vkjy3nw8x7n8asw4es78dyl4q7u7kwlwn7yy0sugxfrjs6z25qe"
+
+verKeyH6 :: String
+verKeyH6 = "cc_cold1lmaet9hdvu9d9jvh34u0un4ndw3yewaq5ch6fnwsctw02xxwylj"
+
+verKey6 :: String
+verKey6 = "cc_cold_vk149up407pvp9p36lldlp4qckqqzn6vm7u5yerwy8d8rqalse3t04q7qsvwl"
+
+xVerKey6 :: String
+xVerKey6 = "cc_cold_xvk149up407pvp9p36lldlp4qckqqzn6vm7u5yerwy8d8rqalse3t04vvqvk3e6l7vzjl7n8ttk646jflumvkgcrdhcstc5wr5etg5n7dnc8nqv5d"
+
+verKeyH7 :: String
+verKeyH7 = "cc_hot17mffcrm3vnfhvyxt7ea3y65e804jfgrk6pjn78aqd9vg7xpq8dv"
+
+verKey7 :: String
+verKey7 = "cc_hot_vk10y48lq72hypxraew74lwjjn9e2dscuwphckglh2nrrpkgweqk5hschnzv5"
+
+xVerKey7 :: String
+xVerKey7 = "cc_hot_xvk10y48lq72hypxraew74lwjjn9e2dscuwphckglh2nrrpkgweqk5h4fplggm56wz9jw6qadq6l5tdvj6qs3v7ggh3hjkt5j8ntga42pvs5rvh0a"

--- a/command-line/test/Command/Script/PreimageSpec.hs
+++ b/command-line/test/Command/Script/PreimageSpec.hs
@@ -107,6 +107,38 @@ spec = do
         specScriptInvalid Malformed
             [iii|any [ #{verKeyH1}, #{verKeyH2}, active_from a]|]
 
+        specScriptPreimageProper
+            "008201828200581ca5b45515a3ff8cb7c02ce351834da324eb6dfc41b5779cb5e6b832aa8204191389"
+            [iii|all [ #{verKeyH5}, active_from 5001]|]
+
+        specScriptPreimageProper
+            "008201828200581ca5b45515a3ff8cb7c02ce351834da324eb6dfc41b5779cb5e6b832aa8204191389"
+            [iii|all [ #{verKey5}, active_from 5001]|]
+
+        specScriptPreimageProper
+            "008201828200581ca5b45515a3ff8cb7c02ce351834da324eb6dfc41b5779cb5e6b832aa8204191389"
+            [iii|all [ #{xVerKey5}, active_from 5001]|]
+
+        specScriptPreimageProper
+            "008201828200581cfefb9596ed670ad2c9978d78fe4eb36ba24cbba0a62fa4cdd0c2dcf58204191389"
+            [iii|all [ #{verKeyH6}, active_from 5001]|]
+
+        specScriptPreimageProper
+            "008201828200581cf6d29c0f7164d37610cbf67b126a993beb24a076d0653f1fa069588f8204191389"
+            [iii|all [ #{verKeyH7}, active_from 5001]|]
+
+        specScriptPreimageProper
+            "008202828200581ca5b45515a3ff8cb7c02ce351834da324eb6dfc41b5779cb5e6b832aa82018282041913898205191771"
+            [iii|any [ #{verKeyH5}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptPreimageProper
+            "008202828200581cfefb9596ed670ad2c9978d78fe4eb36ba24cbba0a62fa4cdd0c2dcf582018282041913898205191771"
+            [iii|any [ #{verKeyH6}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptPreimageProper
+            "008202828200581cf6d29c0f7164d37610cbf67b126a993beb24a076d0653f1fa069588f82018282041913898205191771"
+            [iii|any [ #{verKeyH7}, all [ active_from 5001, active_until 6001]]|]
+
 specScriptPreimageProper :: String -> String -> SpecWith ()
 specScriptPreimageProper expected script = it (script <> " => " <> expected) $ do
     out <- cli ["script", "preimage", script] ""
@@ -129,3 +161,18 @@ verKeyH3 = "addr_shared_vkh175wsm9ckhm3snwcsn72543yguxeuqm7v9r6kl6gx57h8gdydcd9"
 
 verKeyH4 :: String
 verKeyH4 = "addr_shared_vkh1fee6yrlnczhfp77ftunc6snjrv0hv0s92qj2pe47dt4hz8ajp6a"
+
+verKeyH5 :: String
+verKeyH5 = "drep15k6929drl7xt0spvudgcxndryn4kmlzpk4meed0xhqe25nle07s"
+
+verKey5 :: String
+verKey5 = "drep_vk17axh4sc9zwkpsft3tlgpjemfwc0u5mnld80r85zw7zdqcst6w54sdv4a4e"
+
+xVerKey5 :: String
+xVerKey5 = "drep_xvk17axh4sc9zwkpsft3tlgpjemfwc0u5mnld80r85zw7zdqcst6w543mpq3q2vkjy3nw8x7n8asw4es78dyl4q7u7kwlwn7yy0sugxfrjs6z25qe"
+
+verKeyH6 :: String
+verKeyH6 = "cc_cold1lmaet9hdvu9d9jvh34u0un4ndw3yewaq5ch6fnwsctw02xxwylj"
+
+verKeyH7 :: String
+verKeyH7 = "cc_hot17mffcrm3vnfhvyxt7ea3y65e804jfgrk6pjn78aqd9vg7xpq8dv"

--- a/command-line/test/Command/Script/ValidationSpec.hs
+++ b/command-line/test/Command/Script/ValidationSpec.hs
@@ -81,6 +81,24 @@ spec = do
         specScriptNotValidated NotUniformKeyType RecommendedValidation
             [iii|at_least 1 [ #{verKeyH1}, #{verKeyH4} ]|]
 
+        specScriptValidated RequiredValidation
+            [iii|all [ #{verKeyH5}, active_from 5001]|]
+
+        specScriptValidated RequiredValidation
+            [iii|all [ #{verKeyH6}, active_from 5001]|]
+
+        specScriptValidated RequiredValidation
+            [iii|all [ #{verKeyH7}, active_from 5001]|]
+
+        specScriptValidated RequiredValidation
+            [iii|any [ #{verKeyH5}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptValidated RequiredValidation
+            [iii|any [ #{verKeyH6}, all [ active_from 5001, active_until 6001]]|]
+
+        specScriptValidated RequiredValidation
+            [iii|any [ #{verKeyH7}, all [ active_from 5001, active_until 6001]]|]
+
 levelStr :: ValidationLevel -> String
 levelStr = \case
     RequiredValidation -> "--required"
@@ -108,3 +126,12 @@ verKeyH3 = "addr_shared_vkh175wsm9ckhm3snwcsn72543yguxeuqm7v9r6kl6gx57h8gdydcd9"
 
 verKeyH4 :: String
 verKeyH4 = "stake_shared_vkh1nqc00hvlc6cq0sfhretk0rmzw8dywmusp8retuqnnxzajtzhjg5"
+
+verKeyH5 :: String
+verKeyH5 = "drep15k6929drl7xt0spvudgcxndryn4kmlzpk4meed0xhqe25nle07s"
+
+verKeyH6 :: String
+verKeyH6 = "cc_cold1lmaet9hdvu9d9jvh34u0un4ndw3yewaq5ch6fnwsctw02xxwylj"
+
+verKeyH7 :: String
+verKeyH7 = "cc_hot17mffcrm3vnfhvyxt7ea3y65e804jfgrk6pjn78aqd9vg7xpq8dv"

--- a/core/lib/Cardano/Address/Script.hs
+++ b/core/lib/Cardano/Address/Script.hs
@@ -630,12 +630,14 @@ prettyErrValidateScript = \case
         "The hash of verification key is expected to have "
         <> show credentialHashSize <> " bytes."
     NotUniformKeyType ->
-        "All keys of a script must have the same role: either payment or delegation."
+        "All keys of a script must have the same role: payment, delegation, policy, \
+        \representative, committee cold or committee hot."
     Malformed ->
         "Parsing of the script failed. The script should be composed of nested \
         \lists, the verification keys should be bech32-encoded with prefix \
-        \'X_vkh', 'X_vk', 'X_xvk' where X is 'addr_shared', 'stake_shared' or 'policy' and\
-        \timelocks must use non-negative numbers as slots."
+        \'X_vkh', 'X_vk', 'X_xvk' where X is 'addr_shared', 'stake_shared', 'policy', \
+        \'drep', 'cc_cold' or 'cc_hot' and timelocks must use non-negative \
+        \numbers as slots."
     NotRecommended EmptyList ->
         "The list inside a script is empty or only contains timelocks \
         \(which is not recommended)."

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -33,6 +33,7 @@ module Cardano.Address.Style.Shelley
     , roleToIndex
     , Credential (..)
     , CredentialType (..)
+    , hashKey
 
       -- * Key Derivation
       -- $keyDerivation
@@ -1296,3 +1297,13 @@ deriveAddressPublicKeyShelley accXPub role addrIx =
           \index for soft path derivation ( " ++ show addrIx ++ "). This is \
           \either a programmer error, or, we may have reached the maximum \
           \number of addresses for a given wallet."
+
+--
+-- Internal
+--
+
+--- | Computes a 28-byte Blake2b224 digest of a Shelley 'XPub'.
+---
+--- @since 3.13.0
+hashKey :: KeyRole -> Shelley key XPub -> KeyHash
+hashKey cred = KeyHash cred . hashCredential . xpubPublicKey . getKey

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -713,7 +713,6 @@ goldenTestBaseAddressBothFromPub GoldenTestBaseAddress{..} =
                 (DelegationFromKey stakePub)
         baseAddrBothFromKey `shouldBe` baseAddrBothFromPub
 
---TO_DO add script golden
 data KeysHashes = KeysHashes
     {  -- | CIP-1852’s DRep extended signing key (Ed25519-bip32 extended private key), bech32 encoded prefixed with 'drep_xsk'
       drepXsk :: Text


### PR DESCRIPTION
This PR builds on top of the previous one and adds support of CIP 0105 to CLI. In particular the following was added:
1. Support of derivation of all varieties of `drep`, `cc_cold` and `cc_hot` keys, namely extended signing keys, extended verification key and verification keys. 
```
cardano-address key child 1852H/1815H/0H/5/0 < root.xsk > hot.xsk
cardano-address key public --with-chain-code < hot.xsk > hot.xvk
cardano-address key public --without-chain-code < hot.xsk > hot.vk
```
2. Support of making hash from verification keys (both varieties):
```
cardano-address key hash < hot.xvk > hot
cardano-address key hash < hot.vk > hot
```
3. Support for using `drep`, `cc_cold` and `cc_hot` keys, namely extended verification key and verification keys, and verification key hashes in scripts and producing validation, preimage and hash of the script.
```
cardano-address script validate "all [$(cat drep),active_from 5001]"
cardano-address script preimage "all [$(cat drep),active_from 5001]"
cardano-address script hash "all [$(cat drep),active_from 5001]"
```
All produced keys assume bech32 prefixes as specified in CIP-0105.