### PR TITLE
Bump dependencies to support `optparse-applicative` 0.18.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2021-10-05T00:00:00Z
+index-state: 2024-10-05T00:00:00Z
 with-compiler: ghc-8.10.7
 
 constraints: ghcjs-base >=0.2.0.3
@@ -28,35 +28,6 @@ source-repository-package
     tag: 421e8056fabf30ef2f5b01bb61c6880d0dfaa1c8
     --sha256: 0cbsj3dyycykh0lcnsglrzzh898n2iydyw8f2nwyfvfnyx6ac2im
     subdir: foundation
-
--- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
--- Once downstream projects are all upgraded to work with aeson-2, they can
--- be changed to work strictly with aeson 2 only. 
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/hjsonpointer
-    tag: bb99294424e0c5b3c2942c743b545e4b01c12ce8
-    --sha256: 11z5s4xmm6cxy6sdcf9ly4lr0qh3c811hpm0bmlp4c3yq8v3m9rk
-
--- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
--- Once downstream projects are all upgraded to work with aeson-2, they can
--- be changed to work strictly with aeson 2 only.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/hjsonschema
-    tag: 1546af7fc267d5eea805ef223dd2b59ac120b784
-    --sha256: 0sdikhsq6nnhmmvcpwzzrwfn9cn7rg75629qnrx01i5vm5ci4314
-
--- TODO This is a compatibility shim to make it easier for our library dependencies to
--- be compatible with both aeson 1 & 2.  Once downstream projects are all upgraded to
--- work with aeson-2, library dependencies will need to be updated to no longer use
--- this compatibility shim and have bounds to indicate they work with aeson-2 only.
--- After this, the dependency to hw-aeson can be dropped.
-source-repository-package
-    type: git
-    location: https://github.com/haskell-works/hw-aeson
-    tag: ba7c1e41c6e54d6bf9fd1cd013489ac713fc3153
-    --sha256: 1czyn0whgv7czzgwn5y1zgwlkb9p9sn9z9sc9gixrjprcyc0p15p
 
 -- Relax overly strict bounds in hjsonschema and hjsonpointer
 allow-newer:

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 3.6
 
 -- This file has been generated from package.yaml by hpack version 0.34.6.
 --
@@ -58,6 +58,7 @@ library
       Options.Applicative.Derivation
       Options.Applicative.Discrimination
       Options.Applicative.Format
+      Options.Applicative.Help.Pretty.Compat
       Options.Applicative.MnemonicSize
       Options.Applicative.Public
       Options.Applicative.Script
@@ -85,7 +86,8 @@ library
     , fmt
     , memory
     , mtl >=2.2.2 && <2.3
-    , optparse-applicative
+    , optparse-applicative >= 0.18.1
+    , prettyprinter-ansi-terminal
     , process
     , safe
     , template-haskell
@@ -145,10 +147,9 @@ test-suite unit
   default-extensions:
       NoImplicitPrelude
   ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
-  build-tools:
-      cardano-address
   build-tool-depends:
       hspec-discover:hspec-discover
+    , cardano-addresses-cli:cardano-address
   build-depends:
       QuickCheck >=2.14.2
     , aeson

--- a/command-line/lib/Command.hs
+++ b/command-line/lib/Command.hs
@@ -33,10 +33,10 @@ import Options.Applicative
     , subparser
     , (<|>)
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, hsep, string, vsep )
 import System.Console.ANSI
-    ( hSupportsANSIWithoutEmulation )
+    ( hNowSupportsANSI )
 import System.IO
     ( BufferMode (..)
     , Handle
@@ -112,7 +112,7 @@ setup =
   where
     hSetup :: Handle -> IO ()
     hSetup h = do
-      void $ hSupportsANSIWithoutEmulation h
+      void $ hNowSupportsANSI h
       hSetBuffering h NoBuffering
 
 -- | Force the locale text encoding to UTF-8. This is needed because the CLI

--- a/command-line/lib/Command/Address.hs
+++ b/command-line/lib/Command/Address.hs
@@ -19,7 +19,7 @@ import Options.Applicative
     , progDesc
     , subparser
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, hsep, string, vsep )
 import Prelude hiding
     ( mod )

--- a/command-line/lib/Command/Address/Bootstrap.hs
+++ b/command-line/lib/Command/Address/Bootstrap.hs
@@ -34,7 +34,7 @@ import Options.Applicative.Derivation
     ( DerivationPath, castDerivationPath, derivationPathArg, xpubOpt )
 import Options.Applicative.Discrimination
     ( NetworkTag (..), networkTagOpt )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import Options.Applicative.Style
     ( Style (..) )

--- a/command-line/lib/Command/Address/Delegation.hs
+++ b/command-line/lib/Command/Address/Delegation.hs
@@ -25,7 +25,7 @@ import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
 import Options.Applicative.Credential
     ( delegationCredentialArg )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import System.IO
     ( stdin, stdout )

--- a/command-line/lib/Command/Address/Inspect.hs
+++ b/command-line/lib/Command/Address/Inspect.hs
@@ -33,7 +33,7 @@ import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
 import Options.Applicative.Derivation
     ( xpubOpt )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import System.Exit
     ( die )

--- a/command-line/lib/Command/Address/Payment.hs
+++ b/command-line/lib/Command/Address/Payment.hs
@@ -37,7 +37,7 @@ import Options.Applicative
     )
 import Options.Applicative.Discrimination
     ( NetworkTag (..), fromNetworkTag, networkTagOpt )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import Options.Applicative.Script
     ( scriptArg )

--- a/command-line/lib/Command/Address/Pointer.hs
+++ b/command-line/lib/Command/Address/Pointer.hs
@@ -35,7 +35,7 @@ import Options.Applicative
     , metavar
     , progDesc
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import System.IO
     ( stdin, stdout )

--- a/command-line/lib/Command/Address/Reward.hs
+++ b/command-line/lib/Command/Address/Reward.hs
@@ -35,7 +35,7 @@ import Options.Applicative
     )
 import Options.Applicative.Discrimination
     ( fromNetworkTag, networkTagOpt )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import Options.Applicative.Script
     ( scriptArg )

--- a/command-line/lib/Command/Key.hs
+++ b/command-line/lib/Command/Key.hs
@@ -23,7 +23,9 @@ import Options.Applicative
     , subparser
     )
 import Options.Applicative.Help.Pretty
-    ( bold, indent, string, vsep )
+    ( indent, vsep )
+import Options.Applicative.Help.Pretty.Compat
+    ( bold, string )
 import System.IO.Extra
     ( progName )
 

--- a/command-line/lib/Command/Key/Child.hs
+++ b/command-line/lib/Command/Key/Child.hs
@@ -33,7 +33,7 @@ import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
 import Options.Applicative.Derivation
     ( DerivationPath, castDerivationPath, derivationPathArg )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( string )
 import System.IO
     ( stdin, stdout )

--- a/command-line/lib/Command/Key/FromRecoveryPhrase.hs
+++ b/command-line/lib/Command/Key/FromRecoveryPhrase.hs
@@ -30,7 +30,7 @@ import Options.Applicative
     , optional
     , progDesc
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import Options.Applicative.Style
     ( Passphrase (..)

--- a/command-line/lib/Command/Key/Hash.hs
+++ b/command-line/lib/Command/Key/Hash.hs
@@ -25,7 +25,7 @@ import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
 import Options.Applicative.Format
     ( FormatType (..), formatOpt )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( string )
 import System.IO
     ( stdin, stdout )

--- a/command-line/lib/Command/Key/Inspect.hs
+++ b/command-line/lib/Command/Key/Inspect.hs
@@ -26,7 +26,7 @@ import Data.Text
     ( Text )
 import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( string )
 import System.IO
     ( stdin, stdout )

--- a/command-line/lib/Command/Key/Public.hs
+++ b/command-line/lib/Command/Key/Public.hs
@@ -21,7 +21,7 @@ import Data.Maybe
     ( fromJust )
 import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, helper, info, progDesc )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( string )
 import Options.Applicative.Public
     ( PublicType (..), publicOpt )

--- a/command-line/lib/Command/Key/WalletId.hs
+++ b/command-line/lib/Command/Key/WalletId.hs
@@ -36,7 +36,7 @@ import Options.Applicative
     , optional
     , progDesc
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( string )
 import Options.Applicative.Script
     ( scriptTemplateSpendingArg, scriptTemplateStakingArg )

--- a/command-line/lib/Command/Script.hs
+++ b/command-line/lib/Command/Script.hs
@@ -22,7 +22,7 @@ import Options.Applicative
     , progDesc
     , subparser
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import System.IO.Extra
     ( progName )

--- a/command-line/lib/Command/Script/Hash.hs
+++ b/command-line/lib/Command/Script/Hash.hs
@@ -20,7 +20,7 @@ import Codec.Binary.Encoding
     ( AbstractEncoding (..) )
 import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, header, helper, info, progDesc )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import Options.Applicative.Script
     ( scriptArg )

--- a/command-line/lib/Command/Script/Preimage.hs
+++ b/command-line/lib/Command/Script/Preimage.hs
@@ -20,7 +20,7 @@ import Codec.Binary.Encoding
     ( AbstractEncoding (..) )
 import Options.Applicative
     ( CommandFields, Mod, command, footerDoc, header, helper, info, progDesc )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import Options.Applicative.Script
     ( scriptArg )

--- a/command-line/lib/Command/Script/Validation.hs
+++ b/command-line/lib/Command/Script/Validation.hs
@@ -34,7 +34,7 @@ import Options.Applicative
     , optional
     , progDesc
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( bold, indent, string, vsep )
 import Options.Applicative.Script
     ( levelOpt, scriptArg )

--- a/command-line/lib/Options/Applicative/Discrimination.hs
+++ b/command-line/lib/Options/Applicative/Discrimination.hs
@@ -32,7 +32,7 @@ import Options.Applicative
     , option
     , (<|>)
     )
-import Options.Applicative.Help.Pretty
+import Options.Applicative.Help.Pretty.Compat
     ( string, vsep )
 import Options.Applicative.Style
     ( Style (..) )

--- a/command-line/lib/Options/Applicative/Help/Pretty/Compat.hs
+++ b/command-line/lib/Options/Applicative/Help/Pretty/Compat.hs
@@ -1,0 +1,19 @@
+module Options.Applicative.Help.Pretty.Compat
+    ( bold
+    , string
+    , module Options.Applicative.Help.Pretty
+    )
+    where
+
+import Prelude
+
+import Options.Applicative.Help.Pretty hiding
+    ( bold )
+
+import qualified Prettyprinter.Render.Terminal as ANSI
+
+bold :: Doc -> Doc
+bold = annotate ANSI.bold
+
+string :: String -> Doc
+string = pretty

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -72,7 +72,7 @@ library
     , extra
     , fmt
     , hashable
-    , hw-aeson
+    , hw-aeson >=  0.1.9.0
     , memory
     , text
     , unordered-containers

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -121,8 +121,6 @@ import Cardano.Mnemonic
     ( SomeMnemonic, someMnemonicToBytes )
 import Codec.Binary.Encoding
     ( AbstractEncoding (..), encode )
-import Control.Applicative
-    ( Alternative )
 import Control.DeepSeq
     ( NFData )
 import Control.Exception
@@ -481,7 +479,7 @@ prettyErrInspectAddress = \case
 --
 -- @since 2.0.0
 inspectShelleyAddress
-    :: (Alternative m, MonadThrow m)
+    :: MonadThrow m
     => Maybe XPub
     -> Address
     -> m Json.Value
@@ -497,7 +495,7 @@ inspectShelleyAddress = inspectAddress
 --
 -- @since 3.0.0
 inspectAddress
-    :: (Alternative m, MonadThrow m)
+    :: MonadThrow m
     => Maybe XPub
     -> Address
     -> m Json.Value


### PR DESCRIPTION
It seems we need this to make `cardano-wallet` compatible with `cardano-node` 8.12.