### PR TITLE
Support signing keys

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
 - Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105). Also supported in CLI.
 - Fix field for staking scripts in AddressInfo.
 - Rename infoScriptHash field in AddressInfo to infoSpendingScriptHash.
-- signing key and chain code from extended signing key via `cardano-address key private`
+- Get signing key and chain code from extended signing key via `cardano-address key private`
 - Support for new environments `preview` and `preprod`.
 - Supported derivation of root private key using second factor mnemonic or its base16/base64/plain text equivalent
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,16 +1,12 @@
-## [3.14.0] - N/A
-
-### Added
-
- - `hashKey` for Shelley style
- - Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105). Also supported in CLI.
- - Fix field for staking scripts in AddressInfo.
- - Rename infoScriptHash field in AddressInfo to infoSpendingScriptHash.
-
 ## [3.13.0] - N/A
 
 ### Added
 
+- `hashKey` for Shelley style
+- Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105). Also supported in CLI.
+- Fix field for staking scripts in AddressInfo.
+- Rename infoScriptHash field in AddressInfo to infoSpendingScriptHash.
+- signing key and chain code from extended signing key via `cardano-address key private`
 - Support for new environments `preview` and `preprod`.
 - Supported derivation of root private key using second factor mnemonic or its base16/base64/plain text equivalent
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ addr_xvk1grvg8qzmkmw2n0dm4pd0h3j4dv6yglyammyp733eyj629dc3z28v6wk22nfmru6xz0vl2s3
 > :information_source: The last segment in the path is the key index and can be incremented up to `2^31-1` to derive more keys.
 </details>
 
+
 <details>
   <summary>How to generate an extended stake verification key (<strong>stake.xvk</strong>)</summary>
 
@@ -632,6 +633,33 @@ $ cardano-address key hash < hot.xvk > hot
 cc_hot1xk94yxqufrm5sjfv535hlnky8cf9fzg5kvp3r4qz9d5ezua5p8v
 ```
 </details>
+
+<details>
+  <summary>How to get signing key and chain code from an extended signing key (<strong>drep.sk</strong>)</summary>
+
+```console
+$ cat drep.xsk
+drep_xsk1vpdsm49smzmdwhd4kjmm2mdyljjysm746rafjr7r8kgfanj849psw8pfm305g59wng0akw3qzppmfh6k5z7gx66h2vppu022m4eqaj26rh6d7en9tf9fu52hmysjzuacaxfmfya65h8jmddrclwf3kxl8snfs3eg
+
+$ cardano-address key private --signing-key < drep.xsk
+drep_sk1vpdsm49smzmdwhd4kjmm2mdyljjysm746rafjr7r8kgfanj849psw8pfm305g59wng0akw3qzppmfh6k5z7gx66h2vppu022m4eqajg5xmwma
+
+$ cardano-address key private --signing-key --hex < drep.xsk
+605b0dd4b0d8b6d75db5b4b7b56da4fca4486fd5d0fa990fc33d909ece47a943071c29dc5f4450ae9a1fdb3a201043b4df56a0bc836b5753021e3d4add720ec9
+
+$ cardano-address key private --chain-code < drep.xsk
+5a1df4df66655a4a9e5157d9212173b8e993b493baa5cf2db5a3c7dc98d8df3c
+
+$ echo drep_xsk1vpdsm49smzmdwhd4kjmm2mdyljjysm746rafjr7r8kgfanj849psw8pfm305g59wng0akw3qzppmfh6k5z7gx66h2vppu022m4eqaj26rh6d7en9tf9fu52hmysjzuacaxfmfya65h8jmddrclwf3kxl8snfs3eg | cardano-address key inspect
+{
+    "chain_code": "5a1df4df66655a4a9e5157d9212173b8e993b493baa5cf2db5a3c7dc98d8df3c",
+    "extended_key": "605b0dd4b0d8b6d75db5b4b7b56da4fca4486fd5d0fa990fc33d909ece47a943071c29dc5f4450ae9a1fdb3a201043b4df56a0bc836b5753021e3d4add720ec9",
+    "key_type": "private"
+}
+```
+
+</details>
+
 
 <details>
   <summary>How to generate script validation, preimage and script hash from script composed of drep (<strong>drep_script</strong>)</summary>

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -40,6 +40,7 @@ library
       Command.Key.Hash
       Command.Key.Inspect
       Command.Key.Public
+      Command.Key.Private
       Command.Key.WalletId
       Command.RecoveryPhrase
       Command.RecoveryPhrase.Generate
@@ -55,6 +56,7 @@ library
       Options.Applicative.MnemonicSize
       Options.Applicative.Public
       Options.Applicative.Script
+      Options.Applicative.Private
       Options.Applicative.Style
       System.Git.TH
       System.IO.Extra

--- a/command-line/cardano-addresses-cli.cabal
+++ b/command-line/cardano-addresses-cli.cabal
@@ -124,6 +124,7 @@ test-suite unit
       Command.Key.FromRecoveryPhraseSpec
       Command.Key.HashSpec
       Command.Key.InspectSpec
+      Command.Key.PrivateSpec
       Command.Key.PublicSpec
       Command.Key.WalletIdSpec
       Command.KeySpec

--- a/command-line/lib/Command/Key.hs
+++ b/command-line/lib/Command/Key.hs
@@ -35,12 +35,14 @@ import qualified Command.Key.Child as Child
 import qualified Command.Key.FromRecoveryPhrase as FromRecoveryPhrase
 import qualified Command.Key.Hash as Hash
 import qualified Command.Key.Inspect as Inspect
+import qualified Command.Key.Private as Private
 import qualified Command.Key.Public as Public
 import qualified Command.Key.WalletId as WalletId
 
 data Cmd
     = FromRecoveryPhrase FromRecoveryPhrase.Cmd
     | Child Child.Cmd
+    | Private Private.Cmd
     | Public Public.Cmd
     | Inspect Inspect.Cmd
     | Hash Hash.Cmd
@@ -79,6 +81,7 @@ mod liftCmd = command "key" $
     parser = subparser $ mconcat
         [ FromRecoveryPhrase.mod FromRecoveryPhrase
         , Child.mod Child
+        , Private.mod Private
         , Public.mod Public
         , Inspect.mod Inspect
         , Hash.mod Hash
@@ -92,6 +95,7 @@ run :: Cmd -> IO ()
 run = \case
     FromRecoveryPhrase sub -> FromRecoveryPhrase.run sub
     Child sub -> Child.run sub
+    Private sub -> Private.run sub
     Public sub -> Public.run sub
     Inspect sub -> Inspect.run sub
     Hash sub -> Hash.run sub

--- a/command-line/lib/Command/Key/Private.hs
+++ b/command-line/lib/Command/Key/Private.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Command.Key.Private
+    ( Cmd (..)
+    , mod
+    , run
+    ) where
+
+import Prelude hiding
+    ( mod )
+
+import Cardano.Address.Derivation
+    ( xprvChainCode, xprvPrivateKey )
+import Codec.Binary.Encoding
+    ( AbstractEncoding (..) )
+import Data.Maybe
+    ( fromJust )
+import Data.Text
+    ( Text )
+import Options.Applicative
+    ( CommandFields
+    , Mod
+    , command
+    , footerDoc
+    , helper
+    , info
+    , optional
+    , progDesc
+    )
+import Options.Applicative.Format
+    ( FormatType (..), formatOpt )
+import Options.Applicative.Help.Pretty
+    ( pretty )
+import Options.Applicative.Private
+    ( PrivateType (..), privateOpt )
+import System.IO
+    ( stdin, stdout )
+import System.IO.Extra
+    ( hGetXPrv, hPutBytes )
+
+import qualified Cardano.Codec.Bech32.Prefixes as CIP5
+
+data Cmd = Private
+    { keyPart :: PrivateType
+    , outputFormat :: Maybe FormatType
+    } deriving (Show)
+
+mod :: (Cmd -> parent) -> Mod CommandFields parent
+mod liftCmd = command "private" $
+    info (helper <*> fmap liftCmd parser) $ mempty
+        <> progDesc "Get the signing or chain code part of an extended private key"
+        <> footerDoc (Just $ pretty $ mconcat
+            [ "The private key is read from stdin." :: Text
+            , "To get a signing key pass '--signing-key'."
+            , "To get a chain code pass '--chain-code'."
+            , "In order to have the signing key hex encoded pass '--hex'."
+            , "When omitted bech32 encoding will be used."
+            ])
+  where
+    parser = Private
+        <$> privateOpt
+        <*> optional formatOpt
+
+run :: Cmd -> IO ()
+run Private{keyPart,outputFormat} = do
+    (hrp, xprv) <- hGetXPrv stdin allowedPrefixes
+    let bytes = case keyPart of
+            ChainCode -> xprvChainCode xprv
+            SigningKey -> xprvPrivateKey xprv
+    hPutBytes stdout bytes (getFormat keyPart hrp)
+  where
+    prefixes =
+        [ (CIP5.root_xsk, CIP5.root_sk )
+        , (CIP5.acct_xsk, CIP5.acct_sk )
+        , (CIP5.addr_xsk, CIP5.addr_sk )
+        , (CIP5.stake_xsk, CIP5.stake_sk )
+        , (CIP5.root_shared_xsk, CIP5.root_shared_sk )
+        , (CIP5.acct_shared_xsk, CIP5.acct_shared_sk )
+        , (CIP5.addr_shared_xsk, CIP5.addr_shared_sk )
+        , (CIP5.stake_shared_xsk, CIP5.stake_shared_sk )
+        , (CIP5.policy_xsk, CIP5.policy_sk )
+        , (CIP5.drep_xsk, CIP5.drep_sk )
+        , (CIP5.cc_cold_xsk, CIP5.cc_cold_sk )
+        , (CIP5.cc_hot_xsk, CIP5.cc_hot_sk )
+        ]
+    allowedPrefixes = map fst prefixes
+    getFormat ChainCode _ = EBase16
+    getFormat SigningKey hrp = case outputFormat of
+        Just Hex -> EBase16
+        _ -> EBech32 $ fromJust $ lookup hrp prefixes

--- a/command-line/lib/Options/Applicative/Private.hs
+++ b/command-line/lib/Options/Applicative/Private.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+module Options.Applicative.Private
+    (
+    -- * Types
+      PrivateType (..)
+
+    -- * Applicative Parser
+    , privateOpt
+    ) where
+
+import Prelude
+
+import Control.Applicative
+    ( (<|>) )
+import Options.Applicative
+    ( Parser, flag', long )
+
+
+data PrivateType = ChainCode | SigningKey
+    deriving (Eq, Show)
+
+--
+-- Applicative Parser
+--
+
+-- | Parse an 'PrivateType' from the command-line, as set of non-overlapping flags.
+privateOpt :: Parser PrivateType
+privateOpt = cc <|> signing
+  where
+    cc = flag' ChainCode (long "chain-code")
+    signing = flag' SigningKey (long "signing-key")

--- a/command-line/test/Command/Key/PrivateSpec.hs
+++ b/command-line/test/Command/Key/PrivateSpec.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Command.Key.PrivateSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Test.Hspec
+    ( Spec, SpecWith, it, shouldBe, shouldContain )
+import Test.Utils
+    ( cli, describeCmd )
+
+spec :: Spec
+spec = describeCmd [ "key", "private" ] $ do
+    specKeyNotPrivate
+
+specKeyNotPrivate :: SpecWith ()
+specKeyNotPrivate = it "fail if key isn't private" $ do
+    (out, err) <- cli [ "recovery-phrase", "generate" ] ""
+              >>= cli [ "key", "from-recovery-phrase", "icarus" ]
+              >>= cli [ "key", "public", "--with-chain-code" ]
+              >>= cli [ "key", "private", "--chain-code" ]
+
+    out `shouldBe` ""
+    err `shouldContain` "Invalid human-readable prefix."

--- a/command-line/test/Command/Key/PrivateSpec.hs
+++ b/command-line/test/Command/Key/PrivateSpec.hs
@@ -23,6 +23,10 @@ spec = describeCmd [ "key", "private" ] $ do
     specKeyPrivate "shelley" "stake_sk" "1852H/1815H/0H/2/0" "--signing-key"
     specKeyPrivate "shelley" "policy_sk" "1855H/1815H/0H" "--signing-key"
 
+    specKeyPrivate "shared" "acct_shared_sk" "1854H/1815H/0H" "--signing-key"
+    specKeyPrivate "shared" "addr_shared_sk" "1854H/1815H/0H/0/0" "--signing-key"
+    specKeyPrivate "shared" "stake_shared_sk" "1854H/1815H/0H/2/0" "--signing-key"
+
 specKeyNotPrivate :: SpecWith ()
 specKeyNotPrivate = it "fail if key isn't private" $ do
     (out, err) <- cli [ "recovery-phrase", "generate" ] ""

--- a/command-line/test/Command/Key/PrivateSpec.hs
+++ b/command-line/test/Command/Key/PrivateSpec.hs
@@ -27,6 +27,10 @@ spec = describeCmd [ "key", "private" ] $ do
     specKeyPrivate "shared" "addr_shared_sk" "1854H/1815H/0H/0/0" "--signing-key"
     specKeyPrivate "shared" "stake_shared_sk" "1854H/1815H/0H/2/0" "--signing-key"
 
+    specKeyPrivate "shelley" "drep_sk" "1852H/1815H/0H/3/0" "--signing-key"
+    specKeyPrivate "shelley" "cc_cold_sk" "1852H/1815H/0H/4/0" "--signing-key"
+    specKeyPrivate "shelley" "cc_hot_sk" "1852H/1815H/0H/5/0" "--signing-key"
+
 specKeyNotPrivate :: SpecWith ()
 specKeyNotPrivate = it "fail if key isn't private" $ do
     (out, err) <- cli [ "recovery-phrase", "generate" ] ""

--- a/command-line/test/Command/Key/PrivateSpec.hs
+++ b/command-line/test/Command/Key/PrivateSpec.hs
@@ -14,7 +14,14 @@ import Test.Utils
 spec :: Spec
 spec = describeCmd [ "key", "private" ] $ do
     specKeyNotPrivate
+
+    specKeyPrivate "icarus" "acct_sk" "1852H/1815H/0H" "--signing-key"
     specKeyPrivate "icarus" "addr_sk" "1852H/1815H/0H/0/0" "--signing-key"
+
+    specKeyPrivate "shelley" "acct_sk" "1852H/1815H/0H" "--signing-key"
+    specKeyPrivate "shelley" "addr_sk" "1852H/1815H/0H/0/0" "--signing-key"
+    specKeyPrivate "shelley" "stake_sk" "1852H/1815H/0H/2/0" "--signing-key"
+    specKeyPrivate "shelley" "policy_sk" "1855H/1815H/0H" "--signing-key"
 
 specKeyNotPrivate :: SpecWith ()
 specKeyNotPrivate = it "fail if key isn't private" $ do

--- a/command-line/test/Command/Key/PrivateSpec.hs
+++ b/command-line/test/Command/Key/PrivateSpec.hs
@@ -7,13 +7,14 @@ module Command.Key.PrivateSpec
 import Prelude
 
 import Test.Hspec
-    ( Spec, SpecWith, it, shouldBe, shouldContain )
+    ( Spec, SpecWith, it, shouldBe, shouldContain, shouldStartWith )
 import Test.Utils
     ( cli, describeCmd )
 
 spec :: Spec
 spec = describeCmd [ "key", "private" ] $ do
     specKeyNotPrivate
+    specKeyPrivate "icarus" "addr_sk" "1852H/1815H/0H/0/0" "--signing-key"
 
 specKeyNotPrivate :: SpecWith ()
 specKeyNotPrivate = it "fail if key isn't private" $ do
@@ -24,3 +25,11 @@ specKeyNotPrivate = it "fail if key isn't private" $ do
 
     out `shouldBe` ""
     err `shouldContain` "Invalid human-readable prefix."
+
+specKeyPrivate :: String -> String -> String -> String -> SpecWith ()
+specKeyPrivate style hrp path cc = it "succeeds if key is private" $ do
+    out <- cli [ "recovery-phrase", "generate" ] ""
+       >>= cli [ "key", "from-recovery-phrase", style ]
+       >>= cli [ "key", "child", path ]
+       >>= cli [ "key", "private", cc ]
+    out `shouldStartWith` hrp

--- a/core/lib/Cardano/Codec/Bech32/Prefixes.hs
+++ b/core/lib/Cardano/Codec/Bech32/Prefixes.hs
@@ -63,6 +63,7 @@ module Cardano.Codec.Bech32.Prefixes
     , policy_xvk
     , policy_vkh
     , policy_xsk
+    , policy_sk
 
       -- * Keys/hashes for CIP-0105
     , drep_vk
@@ -235,6 +236,9 @@ policy_vkh = [humanReadablePart|policy_vkh|]
 
 policy_xsk :: HumanReadablePart
 policy_xsk = [humanReadablePart|policy_xsk|]
+
+policy_sk :: HumanReadablePart
+policy_sk = [humanReadablePart|policy_sk|]
 
 -- Keys/hashes for CIP-0105
 drep_vk :: HumanReadablePart

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -49,6 +49,7 @@ import Cardano.Address.Derivation
     , pubToBytes
     , toXPub
     , unsafeMkIndex
+    , xprvPrivateKey
     , xprvToBytes
     , xpubFromBytes
     , xpubToBytes
@@ -313,6 +314,8 @@ spec = do
             ,  expectedKeysHashes = KeysHashes
                    { drepXsk = "drep_xsk14rjh4rs2dzm6k5xxe5f73cypzuv02pknfl9xwnsjws8a7ulp530xztarpdlyh05csw2cmnekths7dstq0se3wtza84m4fueffezsjfgassgs9xtfzgehrn0fn7c82uc0rkj06s0w0t80hflzz8cwyry3eg9066uj"
                    , drepXskHex = "a8e57a8e0a68b7ab50c6cd13e8e0811718f506d34fca674e12740fdf73e1a45e612fa30b7e4bbe9883958dcf365de1e6c1607c33172c5d3d7754f3294e4509251d8411029969123371cde99fb075730f1da4fd41ee7acefba7e211f0e20c91ca"
+                   , drepSk = "drep_sk14rjh4rs2dzm6k5xxe5f73cypzuv02pknfl9xwnsjws8a7ulp530xztarpdlyh05csw2cmnekths7dstq0se3wtza84m4fueffezsjfglsqmad"
+                   , drepSkHex = "a8e57a8e0a68b7ab50c6cd13e8e0811718f506d34fca674e12740fdf73e1a45e612fa30b7e4bbe9883958dcf365de1e6c1607c33172c5d3d7754f3294e450925"
                    , drepXvk = "drep_xvk17axh4sc9zwkpsft3tlgpjemfwc0u5mnld80r85zw7zdqcst6w543mpq3q2vkjy3nw8x7n8asw4es78dyl4q7u7kwlwn7yy0sugxfrjs6z25qe"
                    , drepXvkHex = "f74d7ac30513ac1825715fd0196769761fca6e7f69de33d04ef09a0c417a752b1d8411029969123371cde99fb075730f1da4fd41ee7acefba7e211f0e20c91ca"
                    , drepVk = "drep_vk17axh4sc9zwkpsft3tlgpjemfwc0u5mnld80r85zw7zdqcst6w54sdv4a4e"
@@ -356,6 +359,8 @@ spec = do
             ,  expectedKeysHashes = KeysHashes
                    { drepXsk = "drep_xsk1zracgd4mqt32f5cj0ps0wudf78u6lumz7gprgm3j8zec5ahp530weq4z9ayj6jzj33lpj86jkk2gnt0ns0d5sywteexxehvva7gugz99ydmpemzpsfnj49vjvw88q9a2s2hxc9ggxal5q6xsqz5vaat2xqsha72w"
                    , drepXskHex = "10fb8436bb02e2a4d3127860f771a9f1f9aff362f202346e3238b38a76e1a45eec82a22f492d48528c7e191f52b59489adf383db4811cbce4c6cdd8cef91c408a523761cec4182672a9592638e7017aa82ae6c1508377f4068d000a8cef56a30"
+                   , drepSk = "drep_sk1zracgd4mqt32f5cj0ps0wudf78u6lumz7gprgm3j8zec5ahp530weq4z9ayj6jzj33lpj86jkk2gnt0ns0d5sywteexxehvva7gugzqjur0zk"
+                   , drepSkHex = "10fb8436bb02e2a4d3127860f771a9f1f9aff362f202346e3238b38a76e1a45eec82a22f492d48528c7e191f52b59489adf383db4811cbce4c6cdd8cef91c408"
                    , drepXvk = "drep_xvk1wq6ylcpjnwavhveey855tkhdrqdav6yfxvltw0emky9d3erxn9m22gmkrnkyrqn8922eycuwwqt64q4wds2ssdmlgp5dqq9gem6k5vq23ph3c"
                    , drepXvkHex = "70344fe0329bbacbb33921e945daed181bd66889333eb73f3bb10ad8e4669976a523761cec4182672a9592638e7017aa82ae6c1508377f4068d000a8cef56a30"
                    , drepVk = "drep_vk1wq6ylcpjnwavhveey855tkhdrqdav6yfxvltw0emky9d3erxn9mqdrlerg"
@@ -401,6 +406,8 @@ spec = do
             ,  expectedKeysHashes = KeysHashes
                    { drepXsk = "drep_xsk17pwn6d7pu0d6sfzysyk5taux99f5tdqsct7zzthgljyd5zs33azej0tm5ny7ksunthqu84tqg832md6vs3hm392agwx3auhvyjtzxr2l6c0dj47k6zedl4kgugneu04j64fc5uueayydmufdrdaled9k4qllaka6"
                    , drepXskHex = "f05d3d37c1e3dba82444812d45f786295345b410c2fc212ee8fc88da0a118f45993d7ba4c9eb43935dc1c3d56041e2adb74c846fb8955d438d1ef2ec2496230d5fd61ed957d6d0b2dfd6c8e2279e3eb2d5538a7399e908ddf12d1b7bfcb4b6a8"
+                   , drepSk = "drep_sk17pwn6d7pu0d6sfzysyk5taux99f5tdqsct7zzthgljyd5zs33azej0tm5ny7ksunthqu84tqg832md6vs3hm392agwx3auhvyjtzxrgwyexuy"
+                   , drepSkHex = "f05d3d37c1e3dba82444812d45f786295345b410c2fc212ee8fc88da0a118f45993d7ba4c9eb43935dc1c3d56041e2adb74c846fb8955d438d1ef2ec2496230d"
                    , drepXvk = "drep_xvk15j30gk0uex88lc9vh6sfda93lv6zede65mzp7ck56m9pgeqhnht9l4s7m9tad59jmltv3c38nclt942n3feen6ggmhcj6xmmlj6td2qu4ce82"
                    , drepXvkHex = "a4a2f459fcc98e7fe0acbea096f4b1fb342cb73aa6c41f62d4d6ca1464179dd65fd61ed957d6d0b2dfd6c8e2279e3eb2d5538a7399e908ddf12d1b7bfcb4b6a8"
                    , drepVk = "drep_vk15j30gk0uex88lc9vh6sfda93lv6zede65mzp7ck56m9pgeqhnhtqvs6j8t"
@@ -446,6 +453,8 @@ spec = do
             ,  expectedKeysHashes = KeysHashes
                    { drepXsk = "drep_xsk14z6a7nd2q5r03s4gxsrujc59sg757vqqcwxeuc5s874c2rq33az37lwkxpxvh5s4a94sncxp6y7m73pxsuknt7gvethhue5jk5vc5n2hrg95mynhw7mtrshxr5mpku4v8x6lpm05nznrqej70u0fllgfkusexdkv"
                    , drepXskHex = "a8b5df4daa0506f8c2a83407c96285823d4f3000c38d9e62903fab850c118f451f7dd6304ccbd215e96b09e0c1d13dbf4426872d35f90ccaef7e6692b5198a4d571a0b4d927777b6b1c2e61d361b72ac39b5f0edf498a630665e7f1e9ffd09b7"
+                   , drepSk = "drep_sk14z6a7nd2q5r03s4gxsrujc59sg757vqqcwxeuc5s874c2rq33az37lwkxpxvh5s4a94sncxp6y7m73pxsuknt7gvethhue5jk5vc5ngl9zhrx"
+                   , drepSkHex = "a8b5df4daa0506f8c2a83407c96285823d4f3000c38d9e62903fab850c118f451f7dd6304ccbd215e96b09e0c1d13dbf4426872d35f90ccaef7e6692b5198a4d"
                    , drepXvk = "drep_xvk14dwjrplj73qeggdsg4lh4j9tp495asyq9t6augwaue8kqvjg5wq4wxstfkf8waakk8pwv8fkrde2cwd47rklfx9xxpn9ulc7nl7sndcvdjh2m"
                    , drepXvkHex = "ab5d2187f2f4419421b0457f7ac8ab0d4b4ec0802af5de21dde64f603248a381571a0b4d927777b6b1c2e61d361b72ac39b5f0edf498a630665e7f1e9ffd09b7"
                    , drepVk = "drep_vk14dwjrplj73qeggdsg4lh4j9tp495asyq9t6augwaue8kqvjg5wqskrq5yn"
@@ -798,6 +807,12 @@ data KeysHashes = KeysHashes
         -- | CIP-1852’s DRep extended signing key (Ed25519-bip32 extended private key), base16 encoded
     , drepXskHex :: Text
 
+       -- | CIP-1852’s DRep signing key (Ed25519-bip32 non-extended private key), bech32 encoded prefixed with 'drep_sk'
+    , drepSk :: Text
+
+       -- | CIP-1852’s DRep signing key (Ed25519-bip32 non-extended private key), base16 encoded
+    , drepSkHex :: Text
+
        -- | CIP-1852’s DRep extended verification key (Ed25519 public key with chain code), bech32 encoded prefixed with 'drep_xvk'
     , drepXvk :: Text
 
@@ -939,6 +954,8 @@ goldenTestGovernance GoldenTestGovernance{..} =
         let drepXPrv = deriveDRepPrivateKey acctXPrv
         let drepXPrvTxt = bech32With CIP5.drep_xsk  $ getExtendedKeyAddr drepXPrv
         let drepXPrvTxtHex = tob16text . unAddress $ getExtendedKeyAddr drepXPrv
+        let drepPrvTxt = bech32With CIP5.drep_sk  $ getPrivateKeyAddr drepXPrv
+        let drepPrvTxtHex = T.decodeUtf8 $ encode EBase16 $ unAddress $ getPrivateKeyAddr drepXPrv
         let drepXPubTxt = bech32With CIP5.drep_xvk $ getPublicKeyAddr $ toXPub <$> drepXPrv
         let drepXPubTxtHex = tob16text . unAddress $ getPublicKeyAddr $ toXPub <$> drepXPrv
         let drepPubTxt = bech32With CIP5.drep_vk $ getVerKey $ toXPub <$> drepXPrv
@@ -990,6 +1007,8 @@ goldenTestGovernance GoldenTestGovernance{..} =
         let derivedKeysHashes = KeysHashes
                 { drepXsk = drepXPrvTxt
                 , drepXskHex = drepXPrvTxtHex
+                , drepSk = drepPrvTxt
+                , drepSkHex = drepPrvTxtHex
                 , drepXvk = drepXPubTxt
                 , drepXvkHex = drepXPubTxtHex
                 , drepVk = drepPubTxt
@@ -1214,6 +1233,9 @@ shortHex = T.take 8 . T.decodeUtf8 . BAE.convertToBase BAE.Base16 . hashByteStri
 
 getExtendedKeyAddr :: Shelley depth XPrv -> Address
 getExtendedKeyAddr = unsafeMkAddress . xprvToBytes . getKey
+
+getPrivateKeyAddr :: Shelley depth XPrv -> Address
+getPrivateKeyAddr = unsafeMkAddress . xprvPrivateKey . getKey
 
 getPublicKeyAddr :: Shelley depth XPub -> Address
 getPublicKeyAddr = unsafeMkAddress . xpubToBytes . getKey

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -342,6 +342,8 @@ spec = do
                    , ccColdScript2Hex = "119c20cecfedfdba057292f76bb110afa3ab472f9c35a85daf492316"
                    , ccHotXsk = "cc_hot_xsk1mpt30ys7v2ykqms4c83wuednh4hvy3lr27yfhgtp0rhdka8p5300j4d2z77sq2t3kp082qzgkanwkm05mp2u2nwja3ad3pgw9l34a0j5sl5yd6d8pze8dqwksd069kkfdqggk0yytcmet96fre45w64qkgyxl0dt"
                    , ccHotXskHex = "d85717921e6289606e15c1e2ee65b3bd6ec247e357889ba16178eedb74e1a45ef955aa17bd002971b05e750048b766eb6df4d855c54dd2ec7ad8850e2fe35ebe5487e846e9a708b27681d6835fa2dac968108b3c845e379597491e6b476aa0b2"
+                   , ccHotSk = "cc_hot_sk1mpt30ys7v2ykqms4c83wuednh4hvy3lr27yfhgtp0rhdka8p5300j4d2z77sq2t3kp082qzgkanwkm05mp2u2nwja3ad3pgw9l34a0sdh7u7e"
+                   , ccHotSkHex = "d85717921e6289606e15c1e2ee65b3bd6ec247e357889ba16178eedb74e1a45ef955aa17bd002971b05e750048b766eb6df4d855c54dd2ec7ad8850e2fe35ebe"
                    , ccHotXvk = "cc_hot_xvk10y48lq72hypxraew74lwjjn9e2dscuwphckglh2nrrpkgweqk5h4fplggm56wz9jw6qadq6l5tdvj6qs3v7ggh3hjkt5j8ntga42pvs5rvh0a"
                    , ccHotXvkHex = "792a7f83cab90261f72ef57ee94a65ca9b0c71c1be2c8fdd5318c3643b20b52f5487e846e9a708b27681d6835fa2dac968108b3c845e379597491e6b476aa0b2"
                    , ccHotVk = "cc_hot_vk10y48lq72hypxraew74lwjjn9e2dscuwphckglh2nrrpkgweqk5hschnzv5"
@@ -389,6 +391,8 @@ spec = do
                    , ccColdScript2Hex = "2e8b77ecaa9f003978dea86515cee6b97df4dff52298e60198d5b387"
                    , ccHotXsk = "cc_hot_xsk15pt89wppyhr9eqgm5nnu7tna3dfmqxa2u45e4g7krzp9u78p530pez36k8k9n0gw08hn6drxlwxxsgc4jsejv6hvcnkd7gd3zxhstpe3vzde6e98zql6n2cmekklm63dydnt80szdr0h768dexeklrfspc5lznuz"
                    , ccHotXskHex = "a05672b82125c65c811ba4e7cf2e7d8b53b01baae5699aa3d618825e78e1a45e1c8a3ab1ec59bd0e79ef3d3466fb8c6823159433266aecc4ecdf21b111af058731609b9d64a7103fa9ab1bcdadfdea2d2366b3be0268df7f68edc9b36f8d300e"
+                   , ccHotSk = "cc_hot_sk15pt89wppyhr9eqgm5nnu7tna3dfmqxa2u45e4g7krzp9u78p530pez36k8k9n0gw08hn6drxlwxxsgc4jsejv6hvcnkd7gd3zxhstpc7gujxf"
+                   , ccHotSkHex = "a05672b82125c65c811ba4e7cf2e7d8b53b01baae5699aa3d618825e78e1a45e1c8a3ab1ec59bd0e79ef3d3466fb8c6823159433266aecc4ecdf21b111af0587"
                    , ccHotXvk = "cc_hot_xvk10qawpxlz7eytt9yr4xlwtjkw345v0ehzsxdlkks6qralyp975phrzcymn4j2wypl4x43hnddlh4z6gmxkwlqy6xl0a5wmjdnd7xnqrsvak8ry"
                    , ccHotXvkHex = "783ae09be2f648b59483a9bee5cace8d68c7e6e2819bfb5a1a00fbf204bea06e31609b9d64a7103fa9ab1bcdadfdea2d2366b3be0268df7f68edc9b36f8d300e"
                    , ccHotVk = "cc_hot_vk10qawpxlz7eytt9yr4xlwtjkw345v0ehzsxdlkks6qralyp975phqx538xn"
@@ -438,6 +442,8 @@ spec = do
                    , ccColdScript2Hex = "eddd105e3fcb6e60bd23474bdeb9363078f0416bc967bcede1b80194"
                    , ccHotXsk = "cc_hot_xsk1wzamzchtj7m79mjfpg3c02m534ugej5ac0p3s2sresr7vys33azktmjva6flctprqu6m4k4w459x9qkfsz2ahgy5ganjn23djhhkg5e5eyhu7fjxl6tpxtmzh7e2ftuj4qgmawsmcl7sqesn8e0pmh97zs3c3fqj"
                    , ccHotXskHex = "70bbb162eb97b7e2ee490a2387ab748d788cca9dc3c3182a03cc07e612118f4565ee4cee93fc2c230735badaaead0a6282c98095dba094476729aa2d95ef645334c92fcf2646fe96132f62bfb2a4af92a811beba1bc7fd0066133e5e1ddcbe14"
+                   , ccHotSk = "cc_hot_sk1wzamzchtj7m79mjfpg3c02m534ugej5ac0p3s2sresr7vys33azktmjva6flctprqu6m4k4w459x9qkfsz2ahgy5ganjn23djhhkg5cmwegml"
+                   , ccHotSkHex = "70bbb162eb97b7e2ee490a2387ab748d788cca9dc3c3182a03cc07e612118f4565ee4cee93fc2c230735badaaead0a6282c98095dba094476729aa2d95ef6453"
                    , ccHotXvk = "cc_hot_xvk1tazd6lvnf2c9j8m58h6xy56uuyhkee526jgxj2ylaextl0xamd4nfjf0eunydl5kzvhk90aj5jhe92q3h6aph3laqpnpx0j7rhwtu9qe7dhsc"
                    , ccHotXvkHex = "5f44dd7d934ab0591f743df462535ce12f6ce68ad49069289fee4cbfbcdddb6b34c92fcf2646fe96132f62bfb2a4af92a811beba1bc7fd0066133e5e1ddcbe14"
                    , ccHotVk = "cc_hot_vk1tazd6lvnf2c9j8m58h6xy56uuyhkee526jgxj2ylaextl0xamd4swmuygc"
@@ -487,6 +493,8 @@ spec = do
                    , ccColdScript2Hex = "ed41b6d1b16802132c147639cef6264e4fa3b093aeba965962a73061"
                    , ccHotXsk = "cc_hot_xsk14rzh5lvtdhvum6vjfvkwp73mz9gl426cj04xfavnjgmdxrq33azugz0k9sekf2eg70lr34rg5aclr54v30za77xn945kncdm0le6lutxlr5ar355u5awqt2hkmdurv4qv64cmpg39zq2ahjxqken8vk62qunx4hl"
                    , ccHotXskHex = "a8c57a7d8b6dd9cde9924b2ce0fa3b1151faab5893ea64f5939236d30c118f45c409f62c3364ab28f3fe38d468a771f1d2ac8bc5df78d32d6969e1bb7ff3aff166f8e9d1c694e53ae02d57b6dbc1b2a066ab8d85112880aede4605b333b2da50"
+                   , ccHotSk = "cc_hot_sk14rzh5lvtdhvum6vjfvkwp73mz9gl426cj04xfavnjgmdxrq33azugz0k9sekf2eg70lr34rg5aclr54v30za77xn945kncdm0le6lugud8v57"
+                   , ccHotSkHex = "a8c57a7d8b6dd9cde9924b2ce0fa3b1151faab5893ea64f5939236d30c118f45c409f62c3364ab28f3fe38d468a771f1d2ac8bc5df78d32d6969e1bb7ff3aff1"
                    , ccHotXvk = "cc_hot_xvk1g2925ntunmthw66sr8t7v3qe7fls4575wput3936cguzk7m6w4fkd78f68rffef6uqk40dkmcxe2qe4t3kz3z2yq4m0yvpdnxwed55q798msd"
                    , ccHotXvkHex = "428aaa4d7c9ed7776b5019d7e64419f27f0ad3d47078b8963ac2382b7b7a755366f8e9d1c694e53ae02d57b6dbc1b2a066ab8d85112880aede4605b333b2da50"
                    , ccHotVk = "cc_hot_vk1g2925ntunmthw66sr8t7v3qe7fls4575wput3936cguzk7m6w4fs0zjxf8"
@@ -907,6 +915,12 @@ data KeysHashes = KeysHashes
        -- | CIP-1852’s constitutional committee hot extended signing key (Ed25519-bip32 extended private key), base16 encoded
     , ccHotXskHex :: Text
 
+       -- | CIP-1852’s constitutional committee hot signing key (Ed25519-bip32 non-extended private key), bech32 encoded prefixed with 'cc_hot_sk'
+    , ccHotSk :: Text
+
+       -- | CIP-1852’s constitutional committee hot signing key (Ed25519-bip32 non-extended private key), base16 encoded
+    , ccHotSkHex :: Text
+
        -- | CIP-1852’s constitutional committee extended hot verification signing key (Ed25519 public key with chain code), bech32 encoded prefixed with 'cc_hot_xvk'
     , ccHotXvk :: Text
 
@@ -1007,6 +1021,8 @@ goldenTestGovernance GoldenTestGovernance{..} =
         let hotXPrv = deriveCCHotPrivateKey acctXPrv
         let hotXPrvTxt = bech32With CIP5.cc_hot_xsk  $ getExtendedKeyAddr hotXPrv
         let hotXPrvTxtHex = tob16text . unAddress $ getExtendedKeyAddr hotXPrv
+        let hotPrvTxt = bech32With CIP5.cc_hot_sk  $ getPrivateKeyAddr hotXPrv
+        let hotPrvTxtHex = T.decodeUtf8 $ encode EBase16 $ unAddress $ getPrivateKeyAddr hotXPrv
         let hotXPubTxt = bech32With CIP5.cc_hot_xvk $ getPublicKeyAddr $ toXPub <$> hotXPrv
         let hotXPubTxtHex = tob16text . unAddress  $ getPublicKeyAddr $ toXPub <$> hotXPrv
         let hotPubTxt = bech32With CIP5.cc_hot_vk $ getVerKey $ toXPub <$> hotXPrv
@@ -1052,6 +1068,8 @@ goldenTestGovernance GoldenTestGovernance{..} =
                 , ccColdScript2Hex = coldScript2TxtHex
                 , ccHotXsk = hotXPrvTxt
                 , ccHotXskHex = hotXPrvTxtHex
+                , ccHotSk = hotPrvTxt
+                , ccHotSkHex = hotPrvTxtHex
                 , ccHotXvk = hotXPubTxt
                 , ccHotXvkHex = hotXPubTxtHex
                 , ccHotVk = hotPubTxt

--- a/core/test/Cardano/Address/Style/ShelleySpec.hs
+++ b/core/test/Cardano/Address/Style/ShelleySpec.hs
@@ -328,6 +328,8 @@ spec = do
                    , drepScript2Hex = "ae5acf0511255d647c84b3184a2d522bf5f6c5b76b989f49bd383bdd"
                    , ccColdXsk = "cc_cold_xsk1dp84kjq9qa647wr70e2yedzt8e27kwugh8mfw675re0hgm8p530z3d9230cjjzyyzlq04hn94x9q2m9um2tvp2y8fn7tau9l2wfj5ykxqxtgua0lxpf0lfn44md2afyl7dktyvpkmug9u28p6v452flxeuca0v7w"
                    , ccColdXskHex = "684f5b480507755f387e7e544cb44b3e55eb3b88b9f6976bd41e5f746ce1a45e28b4aa8bf129088417c0fade65a98a056cbcda96c0a8874cfcbef0bf53932a12c601968e75ff3052ffa675aedaaea49ff36cb23036df105e28e1d32b4527e6cf"
+                   , ccColdSk = "cc_cold_sk1dp84kjq9qa647wr70e2yedzt8e27kwugh8mfw675re0hgm8p530z3d9230cjjzyyzlq04hn94x9q2m9um2tvp2y8fn7tau9l2wfj5yslmdl88"
+                   , ccColdSkHex = "684f5b480507755f387e7e544cb44b3e55eb3b88b9f6976bd41e5f746ce1a45e28b4aa8bf129088417c0fade65a98a056cbcda96c0a8874cfcbef0bf53932a12"
                    , ccColdXvk = "cc_cold_xvk149up407pvp9p36lldlp4qckqqzn6vm7u5yerwy8d8rqalse3t04vvqvk3e6l7vzjl7n8ttk646jflumvkgcrdhcstc5wr5etg5n7dnc8nqv5d"
                    , ccColdXvkHex = "a9781abfc1604a18ebff6fc35062c000a7a66fdca1323710ed38c1dfc3315beac601968e75ff3052ffa675aedaaea49ff36cb23036df105e28e1d32b4527e6cf"
                    , ccColdVk = "cc_cold_vk149up407pvp9p36lldlp4qckqqzn6vm7u5yerwy8d8rqalse3t04q7qsvwl"
@@ -373,6 +375,8 @@ spec = do
                    , drepScript2Hex = "bba45271823634a8ba9fdb981ad76df02cd2384a4e1b43c41b2734a9"
                    , ccColdXsk = "cc_cold_xsk1dppxrjspxrjj5e5xrmh6yaw6w30arsl5lqcsp09ynyzwwulp530q4tlvug79xx6ja3u32fu9jyy84p6erjmza6twrackm9kfsdpc3ap7uxpempqjftx74qwxnmn7d6pg8pl9zpnc0rese26pfmzl9cmtgg8xsxvu"
                    , ccColdXskHex = "684261ca0130e52a66861eefa275da745fd1c3f4f83100bca49904e773e1a45e0aafece23c531b52ec7915278591087a87591cb62ee96e1f716d96c9834388f43ee1839d84124acdea81c69ee7e6e828387e51067878f30cab414ec5f2e36b42"
+                   , ccColdSk = "cc_cold_sk1dppxrjspxrjj5e5xrmh6yaw6w30arsl5lqcsp09ynyzwwulp530q4tlvug79xx6ja3u32fu9jyy84p6erjmza6twrackm9kfsdpc3aqr79jja"
+                   , ccColdSkHex = "684261ca0130e52a66861eefa275da745fd1c3f4f83100bca49904e773e1a45e0aafece23c531b52ec7915278591087a87591cb62ee96e1f716d96c9834388f4"
                    , ccColdXvk = "cc_cold_xvk1e2mquwugpwnykfftjs4mv3w4uk80f4hjgd2zls5vusz3zuqhr7gnacvrnkzpyjkda2qud8h8um5zswr72yr8s78npj45znk97t3kkssryhkyv"
                    , ccColdXvkHex = "cab60e3b880ba64b252b942bb645d5e58ef4d6f243542fc28ce4051170171f913ee1839d84124acdea81c69ee7e6e828387e51067878f30cab414ec5f2e36b42"
                    , ccColdVk = "cc_cold_vk1e2mquwugpwnykfftjs4mv3w4uk80f4hjgd2zls5vusz3zuqhr7gs3qg4hr"
@@ -420,6 +424,8 @@ spec = do
                    , drepScript2Hex = "7802a8b9e80878cc7b17c451e8778dfeef22cb7b2c2031885b881d68"
                    , ccColdXsk = "cc_cold_xsk1hqtevrzlhtcglwvt5pmgct8ssqx37vjjf3wuydpd6flyqrg33azacap5w5mclacmuycx3xgrtstxgrpzcncf6l840t0klmywc69ryd9zf95taaaseka98yakuj2048slnuekw22qm58majt8alhs438eecehquu0"
                    , ccColdXskHex = "b817960c5fbaf08fb98ba0768c2cf0800d1f32524c5dc2342dd27e400d118f45dc743475378ff71be1306899035c16640c22c4f09d7cf57adf6fec8ec68a3234a24968bef7b0cdba5393b6e494fa9e1f9f33672940dd0fbec967efef0ac4f9ce"
+                   , ccColdSk = "cc_cold_sk1hqtevrzlhtcglwvt5pmgct8ssqx37vjjf3wuydpd6flyqrg33azacap5w5mclacmuycx3xgrtstxgrpzcncf6l840t0klmywc69rydqvncuyc"
+                   , ccColdSkHex = "b817960c5fbaf08fb98ba0768c2cf0800d1f32524c5dc2342dd27e400d118f45dc743475378ff71be1306899035c16640c22c4f09d7cf57adf6fec8ec68a3234"
                    , ccColdXvk = "cc_cold_xvk13wc4cvvr266t4rxm9wyel4deeqxyylvjzjdk5w74lva2xm0dhxt6yjtghmmmpnd62wfmdey5l20pl8envu55phg0hmyk0ml0ptz0nns9cqjlk"
                    , ccColdXvkHex = "8bb15c318356b4ba8cdb2b899fd5b9c80c427d92149b6a3bd5fb3aa36dedb997a24968bef7b0cdba5393b6e494fa9e1f9f33672940dd0fbec967efef0ac4f9ce"
                    , ccColdVk = "cc_cold_vk13wc4cvvr266t4rxm9wyel4deeqxyylvjzjdk5w74lva2xm0dhxtsfpa2qu"
@@ -467,6 +473,8 @@ spec = do
                    , drepScript2Hex = "723e4a09b4897bddf8861f963312a76df8183b6ee438bdd4157b5d6c"
                    , ccColdXsk = "cc_cold_xsk1hqe5kcsq59mx4t9nxrctmth0ppz9gda0gnppyll3h9rxcyq33az4uy3u6qhzuhjsstzca9awgsx27j07hxhrkrk6487nvywp0ag669m4v6lj3knq7e6pxaujy98akn5exhgk44ftruepkte0hdm74dd8zceqnk2h"
                    , ccColdXskHex = "b8334b6200a1766aacb330f0bdaeef08445437af44c2127ff1b9466c10118f455e123cd02e2e5e5082c58e97ae440caf49feb9ae3b0edaa9fd3611c17f51ad177566bf28da60f674137792214fdb4e9935d16ad52b1f321b2f2fbb77eab5a716"
+                   , ccColdSk = "cc_cold_sk1hqe5kcsq59mx4t9nxrctmth0ppz9gda0gnppyll3h9rxcyq33az4uy3u6qhzuhjsstzca9awgsx27j07hxhrkrk6487nvywp0ag669c5qtm3p"
+                   , ccColdSkHex = "b8334b6200a1766aacb330f0bdaeef08445437af44c2127ff1b9466c10118f455e123cd02e2e5e5082c58e97ae440caf49feb9ae3b0edaa9fd3611c17f51ad17"
                    , ccColdXvk = "cc_cold_xvk1lmqejccjpxsd9cl4uavxj0jryjlfk5r8wemr0d8saal49lttp2482e4l9rdxpan5zdmeyg20md8fjdw3dt2jk8ejrvhjlwmha266w9syf55nr"
                    , ccColdXvkHex = "fec199631209a0d2e3f5e758693e4324be9b5067767637b4f0ef7f52fd6b0aaa7566bf28da60f674137792214fdb4e9935d16ad52b1f321b2f2fbb77eab5a716"
                    , ccColdVk = "cc_cold_vk1lmqejccjpxsd9cl4uavxj0jryjlfk5r8wemr0d8saal49lttp24q6lw08l"
@@ -853,6 +861,12 @@ data KeysHashes = KeysHashes
        -- | CIP-1852’s constitutional committee cold extended signing key (Ed25519-bip32 extended private key), base16 encoded
     , ccColdXskHex :: Text
 
+       -- | CIP-1852’s constitutional committee cold signing key (Ed25519-bip32 non-extended private key), bech32 encoded prefixed with 'cc_cold_sk'
+    , ccColdSk :: Text
+
+       -- | CIP-1852’s constitutional committee cold signing key (Ed25519-bip32 non-extended private key), base16 encoded
+    , ccColdSkHex :: Text
+
        -- | CIP-1852’s constitutional committee extended cold verification signing key (Ed25519 public key with chain code), bech32 encoded prefixed with 'cc_cold_xvk'
     , ccColdXvk :: Text
 
@@ -973,6 +987,9 @@ goldenTestGovernance GoldenTestGovernance{..} =
         let coldXPrv = deriveCCColdPrivateKey acctXPrv
         let coldXPrvTxt = bech32With CIP5.cc_cold_xsk $ getExtendedKeyAddr coldXPrv
         let coldXPrvTxtHex = tob16text . unAddress $ getExtendedKeyAddr coldXPrv
+        let coldXPrvTxt = bech32With CIP5.cc_cold_xsk  $ getExtendedKeyAddr coldXPrv
+        let coldPrvTxt = bech32With CIP5.cc_cold_sk  $ getPrivateKeyAddr coldXPrv
+        let coldPrvTxtHex = T.decodeUtf8 $ encode EBase16 $ unAddress $ getPrivateKeyAddr coldXPrv
         let coldXPubTxt = bech32With CIP5.cc_cold_xvk $ getPublicKeyAddr $ toXPub <$> coldXPrv
         let coldXPubTxtHex = tob16text . unAddress  $ getPublicKeyAddr $ toXPub <$> coldXPrv
         let coldPubTxt = bech32With CIP5.cc_cold_vk $ getVerKey $ toXPub <$> coldXPrv
@@ -1021,6 +1038,8 @@ goldenTestGovernance GoldenTestGovernance{..} =
                 , drepScript2Hex = drepScript2TxtHex
                 , ccColdXsk = coldXPrvTxt
                 , ccColdXskHex = coldXPrvTxtHex
+                , ccColdSk = coldPrvTxt
+                , ccColdSkHex = coldPrvTxtHex
                 , ccColdXvk = coldXPubTxt
                 , ccColdXvkHex = coldXPubTxtHex
                 , ccColdVk = coldPubTxt


### PR DESCRIPTION
This PR enables to decompose ANY extended signing key `*_xsk` into signing key and chain code.

New cli command was added which operate as follows:
```
$ cat drep.xsk
drep_xsk1vpdsm49smzmdwhd4kjmm2mdyljjysm746rafjr7r8kgfanj849psw8pfm305g59wng0akw3qzppmfh6k5z7gx66h2vppu022m4eqaj26rh6d7en9tf9fu52hmysjzuacaxfmfya65h8jmddrclwf3kxl8snfs3eg

$ cardano-address key private --signing-key < drep.xsk
drep_sk1vpdsm49smzmdwhd4kjmm2mdyljjysm746rafjr7r8kgfanj849psw8pfm305g59wng0akw3qzppmfh6k5z7gx66h2vppu022m4eqajg5xmwma

$ cardano-address key private --signing-key --hex < drep.xsk
605b0dd4b0d8b6d75db5b4b7b56da4fca4486fd5d0fa990fc33d909ece47a943071c29dc5f4450ae9a1fdb3a201043b4df56a0bc836b5753021e3d4add720ec9

$ cardano-address key private --chain-code < drep.xsk
5a1df4df66655a4a9e5157d9212173b8e993b493baa5cf2db5a3c7dc98d8df3c

$ echo drep_xsk1vpdsm49smzmdwhd4kjmm2mdyljjysm746rafjr7r8kgfanj849psw8pfm305g59wng0akw3qzppmfh6k5z7gx66h2vppu022m4eqaj26rh6d7en9tf9fu52hmysjzuacaxfmfya65h8jmddrclwf3kxl8snfs3eg | cardano-address key inspect
{
    "chain_code": "5a1df4df66655a4a9e5157d9212173b8e993b493baa5cf2db5a3c7dc98d8df3c",
    "extended_key": "605b0dd4b0d8b6d75db5b4b7b56da4fca4486fd5d0fa990fc33d909ece47a943071c29dc5f4450ae9a1fdb3a201043b4df56a0bc836b5753021e3d4add720ec9",
    "key_type": "private"
}
```


Also test vectors from CIP-0105 were verified (https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105)