### PR TITLE
FIX: Inspecting reward accounts uses wrong `AddressInfo` field for staking scripts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
  - `hashKey` for Shelley style
  - Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105). Also supported in CLI.
  - Fix field for staking scripts in AddressInfo.
+ - Rename infoScriptHash field in AddressInfo to infoSpendingScriptHash.
 
 ## [3.13.0] - N/A
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
  - `hashKey` for Shelley style
  - Key derivation support for DRep, CCCold and CCHot in accordance to [CIP--105](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105). Also supported in CLI.
+ - Fix field for staking scripts in AddressInfo.
 
 ## [3.13.0] - N/A
 

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -756,7 +756,7 @@ instance ToJSON AddressInfo where
         ++ jsonHash "spending_key_hash" CIP5.addr_vkh infoSpendingKeyHash
         ++ jsonHash "stake_key_hash" CIP5.stake_vkh infoStakeKeyHash
         ++ jsonHash "spending_shared_hash" CIP5.addr_shared_vkh infoSpendingScriptHash
-        ++ jsonHash "stake_shared_hash" CIP5.stake_shared_vkh infoSpendingScriptHash
+        ++ jsonHash "stake_shared_hash" CIP5.stake_shared_vkh infoStakeScriptHash
         ++ jsonHash "stake_script_hash" CIP5.stake_vkh infoStakeScriptHash
       where
         getPointer ByValue = Nothing

--- a/core/lib/Cardano/Address/Style/Shelley.hs
+++ b/core/lib/Cardano/Address/Style/Shelley.hs
@@ -666,7 +666,7 @@ parseAddressInfoShelley AddressParts{..} = case addrType of
     0b11110000 | addrRestLength == credentialHashSize ->
         Right addressInfo
             { infoStakeReference = Just ByValue
-            , infoScriptHash = Just addrHash1
+            , infoStakeScriptHash = Just addrHash1
             }
     unknown -> Left (UnknownType unknown)
 

--- a/jsapi/test/api.test.ts
+++ b/jsapi/test/api.test.ts
@@ -215,9 +215,9 @@ describe('inspectAddress', () => {
       "address_style": "Shelley",
       "address_type": 15,
       "network_tag": 0,
-      "spending_shared_hash": "61766572796e69636561646472726573736c6f6c6f6c6f6c6f6c6f6c",
-      "spending_shared_hash_bech32": "addr_shared_vkh1v9mx2unede5kxetpv3j8yun9wdekcmmvdakx7mr0d3hkcuuhu9r",
       "stake_reference": "by value",
+      "stake_script_hash": "61766572796e69636561646472726573736c6f6c6f6c6f6c6f6c6f6c",
+      "stake_script_hash_bech32": "stake_vkh1v9mx2unede5kxetpv3j8yun9wdekcmmvdakx7mr0d3hkcjpqtv8",
       "stake_shared_hash": "61766572796e69636561646472726573736c6f6c6f6c6f6c6f6c6f6c",
       "stake_shared_hash_bech32": "stake_shared_vkh1v9mx2unede5kxetpv3j8yun9wdekcmmvdakx7mr0d3hkcjta3en",
     }));


### PR DESCRIPTION
I would expect that inspecting a reward account address would use the `infoStakeScriptHash` field of `AddressInfo`, but it is using `infoScriptHash`. The pubkey version is using `infoStakeKeyHash` so this seems like a bug. I ran the tests both before and after the change, and all tests pass; they don't seem to cover this.

If this is the intended behavior, feel free to close this PR.