### PR TITLE
Use foliage hackage overlay ghcjs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,11 +14,10 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 
 repository ghcjs-overlay
-  url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/7ed50a3159d95499981b1c384ddc05639032789e
+  url: https://input-output-hk.github.io/hackage-overlay-ghcjs/
   secure: True
   root-keys:
   key-threshold: 0
-  --sha256: sha256-LvLpoKZy44DfMDLIqj1kodQ+WBo/BtGGJ23Iok2LVO8=
 
 -- Avoid conflict in `hjsonschema`
 -- src/Import.hs:2:16: error: [GHC-69158]

--- a/cabal.project
+++ b/cabal.project
@@ -17,7 +17,10 @@ repository ghcjs-overlay
   url: https://input-output-hk.github.io/hackage-overlay-ghcjs/
   secure: True
   root-keys:
-  key-threshold: 0
+    3838d0dfa046bb3d16de9ae0823dab1dd937ee336f9bcaa87c85b36443aee7f6
+    92e8a83a0df4f99ff0372b6dcdb008c52971d1d53b1df621630f5a650fbf1f0a
+    d5f108840fa2addca04caa82bc4c60ce41df7c0d3133baf6716b05a4dce11b6c
+  key-threshold: 3
 
 -- Avoid conflict in `hjsonschema`
 -- src/Import.hs:2:16: error: [GHC-69158]

--- a/core/cardano-addresses.cabal
+++ b/core/cardano-addresses.cabal
@@ -122,3 +122,4 @@ test-suite unit
   if flag(release)
     ghc-options: -Werror
   default-language: Haskell2010
+

--- a/flake.lock
+++ b/flake.lock
@@ -222,6 +222,23 @@
         "type": "github"
       }
     },
+    "hackageGHCJS": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1730758237,
+        "narHash": "sha256-eVQEqwLrCjR/fauNjlHwry9+CVqkC5G0cDJTiQxcbcg=",
+        "owner": "input-output-hk",
+        "repo": "hackage-overlay-ghcjs",
+        "rev": "7ed50a3159d95499981b1c384ddc05639032789e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "gh-pages",
+        "repo": "hackage-overlay-ghcjs",
+        "type": "github"
+      }
+    },
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
@@ -724,6 +741,7 @@
       "inputs": {
         "CHaP": "CHaP",
         "flake-utils": "flake-utils",
+        "hackageGHCJS": "hackageGHCJS",
         "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
         "nixpkgs": [

--- a/flake.lock
+++ b/flake.lock
@@ -225,16 +225,16 @@
     "hackageGHCJS": {
       "flake": false,
       "locked": {
-        "lastModified": 1730758237,
-        "narHash": "sha256-eVQEqwLrCjR/fauNjlHwry9+CVqkC5G0cDJTiQxcbcg=",
+        "lastModified": 1731576249,
+        "narHash": "sha256-yHw9Bscx2iG9IE0W7LhLlkuTVA7uduSn9bjvLFChevE=",
         "owner": "input-output-hk",
         "repo": "hackage-overlay-ghcjs",
-        "rev": "7ed50a3159d95499981b1c384ddc05639032789e",
+        "rev": "bbf51663dfedb5cfc0497cabe4157d2e495db775",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "gh-pages",
+        "ref": "repo",
         "repo": "hackage-overlay-ghcjs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
       flake = false;
     };
     hackageGHCJS = {
-      url = "github:input-output-hk/hackage-overlay-ghcjs?ref=gh-pages";
+      url = "github:input-output-hk/hackage-overlay-ghcjs?ref=repo";
       flake = false;
     };
     flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,10 @@
       url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
       flake = false;
     };
+    hackageGHCJS = {
+      url = "github:input-output-hk/hackage-overlay-ghcjs?ref=gh-pages";
+      flake = false;
+    };
     flake-utils.url = "github:numtide/flake-utils";
     iohkNix = {
       url = "github:input-output-hk/iohk-nix";
@@ -18,7 +22,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, haskellNix, iohkNix, CHaP, ... }:
+  outputs = { self, nixpkgs, flake-utils, haskellNix, iohkNix, CHaP, hackageGHCJS, ... }:
     let
       inherit (nixpkgs) lib;
       inherit (flake-utils.lib) eachSystem mkApp;
@@ -54,7 +58,7 @@
           };
 
           haskellProject = (import ./nix/haskell.nix {
-            inherit system CHaP;
+            inherit system CHaP hackageGHCJS;
             inherit (pkgs) haskell-nix;
           });
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -1,7 +1,7 @@
 ############################################################################
 # Builds Haskell packages with Haskell.nix
 ############################################################################
-{ system, CHaP, haskell-nix }:
+{ system, CHaP, hackageGHCJS, haskell-nix }:
 haskell-nix.cabalProject' (
   { pkgs
   , lib
@@ -28,6 +28,7 @@ haskell-nix.cabalProject' (
 
     inputMap = {
       "https://chap.intersectmbo.org/" = CHaP;
+      "https://input-output-hk.github.io/hackage-overlay-ghcjs/" = hackageGHCJS;
     };
 
     # Setting this to builtins.currentSystem allows --impure to be used


### PR DESCRIPTION
Uses the `repo` branch in hackage-overlay-ghcjs created manually using https://github.com/input-output-hk/hackage-overlay-ghcjs/pull/6