### PR TITLE
Prepare publication to hackage

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,10 +10,6 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state:
-  , hackage.haskell.org 2024-11-14T09:17:39Z
-  , cardano-haskell-packages 2024-11-20T20:05:41Z
-
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 
@@ -21,6 +17,10 @@ if impl(ghc>=9.8)
   allow-newer: *:template-haskell, *:base, *:deepseq, *:ghc-prim, *:time
 
 active-repositories: hackage.haskell.org, cardano-haskell-packages
+
+index-state:
+  , hackage.haskell.org 2024-11-14T09:17:39Z
+  , cardano-haskell-packages 2025-01-23T00:00:00Z
 
 packages:
   cardano-addresses.cabal

--- a/cardano-addresses.cabal
+++ b/cardano-addresses.cabal
@@ -94,10 +94,10 @@ library
     , bech32-th >= 1.1.7 && < 1.2
     , binary
     , bytestring >= 0.10.6 && < 0.13
-    , cardano-crypto
+    , cardano-crypto >= 1.2.0
     , cborg >= 0.2.1 && <0.3
     , containers >= 0.5 && < 0.8
-    , cryptonite
+    , crypton >= 0.32 && < 1.1
     , deepseq >= 1.4.4.0 && < 1.6
     , digest
     , either
@@ -197,7 +197,7 @@ test-suite unit
     , bytestring >= 0.10.6 && < 0.13
     , cardano-addresses
     , cardano-crypto
-    , cryptonite
+    , crypton
     , containers >= 0.5 && < 0.8
     , hspec >= 2.11.0 && < 2.12
     , hspec-golden >=0.1.0.3 && <0.2

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1736937016,
-        "narHash": "sha256-dmLSu2SvSaTDjSE03cU6DwY62J3nWJbVhIn/kKtMwJg=",
+        "lastModified": 1740589390,
+        "narHash": "sha256-3sejZgLk9MkGBWz5p+XH8orjpb1RDwXh4Kn1j9kWjDY=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "045875beec586ff57a7333c0563fd5c2b1a308fa",
+        "rev": "1e58f5e988d05265e8db958fa044b5a440358226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
* put bounds on cardano-crypto dependency: we set the bound in such a way both CHaP and Hackage can provide a valid version
* replace cryptonite with crypton

#294 