### PR TITLE
Tweak cabal configuration to support CHaP and Hackage

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,7 +19,7 @@ if impl(ghc>=9.8)
 active-repositories: hackage.haskell.org, cardano-haskell-packages
 
 index-state:
-  , hackage.haskell.org 2024-11-14T09:17:39Z
+  , hackage.haskell.org 2025-03-01T16:00:00Z
   , cardano-haskell-packages 2025-01-23T00:00:00Z
 
 packages:

--- a/cardano-addresses.cabal
+++ b/cardano-addresses.cabal
@@ -11,8 +11,15 @@ author:         IOHK
 maintainer:     hal@cardanofoundation.org
 copyright:      2020 Input Output (Hong Kong) Ltd., 2021-2022 Input Output Global Inc. (IOG), 2023-2025 Intersect
 license:        Apache-2.0
+license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
+    ChangeLog.md
+    CONTRIBUTING.md
+    LICENSE
+    NOTICE
+    README.md
+    SECURITY.md
     ./schemas/address-inspect.json
 
 source-repository head

--- a/cardano-addresses.cabal
+++ b/cardano-addresses.cabal
@@ -94,7 +94,7 @@ library
     , bech32-th >= 1.1.7 && < 1.2
     , binary
     , bytestring >= 0.10.6 && < 0.13
-    , cardano-crypto >= 1.2.0
+    , cardano-crypto >= 1.2.0 && < 1.4.0
     , cborg >= 0.2.1 && <0.3
     , containers >= 0.5 && < 0.8
     , crypton >= 0.32 && < 1.1


### PR DESCRIPTION
As of this commit, version 1.3.0 of cardano-crypto has been published to https://hackage.haskell.org/. This version is identical to version 1.2.0 which is published to https://chap.intersectmbo.org, so it's fine to leave the option to the end-user to use one or the other repository.

We keep the CHaP configuration in the `cabal.project` with updated indices as it can be useful for contributors and provides a reference with "pinned" versions for building in CI, but as it's not published to the package repository, it won't affect build plan downstream which will use whatever local configuration.